### PR TITLE
Add simple rabbitmq configuration

### DIFF
--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   rabbitmq:
     image: rabbitmq:latest
     hostname: rabbitmq
+    container_name: rabbitmq
     restart: always
     networks:
       - rabbitmq_network
@@ -10,6 +11,7 @@ services:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
     volumes:
+      - ./enabled_plugins:/etc/rabbitmq/enabled_plugins
       - ./rabbitmq:/var/lib/rabbitmq
       - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     ports:

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3.9"
 services:
   rabbitmq:
-    image: rabbitmq:3.10.7-management
+    image: rabbitmq:latest
     hostname: rabbitmq
     restart: always
+    networks:
+      - rabbitmq_network
     environment:
       - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
       - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
@@ -16,3 +18,7 @@ services:
       - 4369:4369
       - 25672:25672
       - 35197:35197
+
+networks:
+  rabbitmq_network:
+    name: rabbitmq_network

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  rabbitmq:
+    image: rabbitmq:3.10.7-management
+    hostname: rabbitmq
+    restart: always
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+    volumes:
+      - ./rabbitmq:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
+    ports:
+      - 15672:15672
+      - 5672:5672
+      - 4369:4369
+      - 25672:25672
+      - 35197:35197

--- a/rabbitmq/enabled_plugins
+++ b/rabbitmq/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_consistent_hash_exchange].

--- a/rabbitmq/rabbitmq.conf
+++ b/rabbitmq/rabbitmq.conf
@@ -1,0 +1,3 @@
+disk_free_limit.absolute = 2147483648
+log.file.level = info
+heartbeat = 60


### PR DESCRIPTION
Простой docker-compose для rabbitmq. Необходимо развернуть highly available rabbitmq  кластер, на данный момент это делается вручную с помощью rabbitmqctl, также будут использоваться конфигурационные файлы.
Можно сформировать кластер, используя kubernetes, однако он требует большое количество ресурсов. Учитывая масштаб проекта(понадобится всего 2-3 ноды), на данный момент не вижу смысла настраивать  kubernetes.