### PR TITLE
Disable autocomplete in ip address fields

### DIFF
--- a/front/src/static/config_host.html
+++ b/front/src/static/config_host.html
@@ -55,7 +55,7 @@
         <input type="number" class="form-control form-control-sm" id="config_host_send_udp_data_size_input_field" name="config_host_send_udp_data_size_input_field" value='' placeholder='Объём в байтах (1-65535)'>
         <label id="config_host_send_udp_data_label" for="config_host_send_udp_data_label" class="text-sm">Получатель (IP / порт)</label>
         <div class="input-group flex-nowrap">
-            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_host_send_udp_data_ip_input_field" name="config_host_send_udp_data_ip_input_field" value='' placeholder='IP адрес'>
+            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_host_send_udp_data_ip_input_field" name="config_host_send_udp_data_ip_input_field" value='' autocomplete="none" placeholder='IP адрес'>
             <input type="number" class="px-2 form-control form-control-sm" style="width:35% !important" id="config_host_send_udp_data_port_input_field" name="config_host_send_udp_data_port_input_field" min="0" max="65535" value="" placeholder='Порт'>
         </div>
     </div>
@@ -66,7 +66,7 @@
         <input type="number" class="form-control form-control-sm" id="config_host_send_tcp_data_size_input_field" name="config_host_send_tcp_data_size_input_field" value='' placeholder='Объём в байтах (1-65535)'>
         <label id="config_host_send_tcp_data_label" for="config_host_send_tcp_data_label" class="text-sm">Получатель (IP / порт)</label>
         <div class="input-group flex-nowrap">
-            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_host_send_tcp_data_ip_input_field" name="config_host_send_tcp_data_ip_input_field" value='' placeholder='IP адрес'>
+            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_host_send_tcp_data_ip_input_field" name="config_host_send_tcp_data_ip_input_field" value='' autocomplete="none" placeholder='IP адрес'>
             <input type="number" class="px-2 form-control form-control-sm" style="width:35% !important" id="config_host_send_tcp_data_port_input_field" name="config_host_send_tcp_data_port_input_field" min="0" max="65535" value="" placeholder='Порт'>
         </div>
     </div>
@@ -83,10 +83,10 @@
     <div class="form-group pt-1" name="config_host_select_input">
         <label id="config_host_add_route_label" for="config_host_add_route_label" class="text-sm">IP-адрес / Маска</label>
         <div class="input-group flex-nowrap">
-            <input type="text" class="form-control form-control-sm w-75" id="config_host_add_route_ip_input_field" name="config_host_add_route_ip_input_field" value=''>
+            <input type="text" class="form-control form-control-sm w-75" id="config_host_add_route_ip_input_field" name="config_host_add_route_ip_input_field" autocomplete="none" value=''>
             <input type="number" class="px-2 form-control form-control-sm w-25" id="config_host_add_route_mask_input_field" name="config_host_add_route_mask_input_field" min="0" max="32" value="0">
         </div>
-        <input type="text" class="form-control form-control-sm" id="config_host_add_route_gw_input_field" name="config_host_add_route_gw_input_field" value='' placeholder='IP адрес шлюза'>
+        <input type="text" class="form-control form-control-sm" id="config_host_add_route_gw_input_field" name="config_host_add_route_gw_input_field" value='' autocomplete="none" placeholder='IP адрес шлюза'>
     </div>
 </script>
 
@@ -98,7 +98,7 @@
     </div>
     <label id="config_host_ip_label_example" for="config_host_ip_example" class="text-sm">IP-адрес / Маска</label>
     <div class="input-group pb-2 flex-nowrap">
-        <input type="text" class="form-control form-control-sm w-75" id="config_host_ip_example" name="config_host_ip_example" value=''>
+        <input type="text" class="form-control form-control-sm w-75" id="config_host_ip_example" name="config_host_ip_example" autocomplete="none" value=''>
         <input type="number" class="px-2 form-control form-control-sm w-25" id="config_host_mask_example" name="config_host_mask_example" min="0" max="32" value="0">
     </div>
 </script>

--- a/front/src/static/config_router.html
+++ b/front/src/static/config_router.html
@@ -20,7 +20,7 @@
     </div>
     <label id="config_router_ip_label_example" for="config_router_ip_example" class="text-sm">IP-адрес / Маска</label>
     <div class="input-group pb-2 flex-nowrap">
-        <input type="text" class="form-control form-control-sm w-75" id="config_router_ip_example" name="config_router_ip_example" value=''>
+        <input type="text" class="form-control form-control-sm w-75" id="config_router_ip_example" name="config_router_ip_example" autocomplete="none" value=''>
         <input type="number" class="px-2 form-control form-control-sm w-25" id="config_router_mask_example" name="config_router_mask_example" min="0" max="32" value="0">
     </div>
 </script>
@@ -59,7 +59,7 @@
         </select>
         <label id="config_router_add_ip_mask_label_example" for="config_router_add_ip_mask_label_example" class="text-sm">IP-адрес / Маска</label>
         <div class="input-group pb-2 flex-nowrap">
-            <input type="text" class="form-control form-control-sm w-75" id="config_router_add_ip_mask_ip_input_field" name="config_router_add_ip_mask_ip_input_field" value=''>
+            <input type="text" class="form-control form-control-sm w-75" id="config_router_add_ip_mask_ip_input_field" name="config_router_add_ip_mask_ip_input_field" autocomplete="none" value=''>
             <input type="number" class="px-2 form-control form-control-sm w-25" id="config_router_add_ip_mask_mask_input_field" name="config_router_add_ip_mask_mask_input_field" min="0" max="32" value="0">
         </div>
     </div>
@@ -76,10 +76,10 @@
     <div class="form-group pt-1" name="config_router_select_input">
         <label id="config_router_add_route_label" for="config_router_add_route_label" class="text-sm">IP-адрес / Маска</label>
         <div class="input-group flex-nowrap">
-            <input type="text" class="form-control form-control-sm w-75" id="config_router_add_route_ip_input_field" name="config_router_add_route_ip_input_field" value=''>
+            <input type="text" class="form-control form-control-sm w-75" id="config_router_add_route_ip_input_field" name="config_router_add_route_ip_input_field" autocomplete="none" value=''>
             <input type="number" class="px-2 form-control form-control-sm w-25" id="config_router_add_route_mask_input_field" name="config_router_add_route_mask_input_field" min="0" max="32" value="0">
         </div>
-        <input type="text" class="form-control form-control-sm" id="config_router_add_route_gw_input_field" name="config_router_add_route_gw_input_field" value='' placeholder='IP адрес шлюза'>
+        <input type="text" class="form-control form-control-sm" id="config_router_add_route_gw_input_field" name="config_router_add_route_gw_input_field" value='' autocomplete="none" placeholder='IP адрес шлюза'>
     </div>
 </script>
 
@@ -93,7 +93,7 @@
             class="text-sm">IP-адрес / Маска</label>
         <div class="input-group pb-2 flex-nowrap">
             <input type="text" class="form-control form-control-sm w-75"
-                id="config_router_add_subinterface_ip_input_field" name="config_router_add_subinterface_ip_input_field"
+                id="config_router_add_subinterface_ip_input_field" name="config_router_add_subinterface_ip_input_field" autocomplete="none"
                 value=''>
             <input type="number" class="px-2 form-control form-control-sm w-25"
                 id="config_router_add_subinterface_mask_input_field"

--- a/front/src/static/config_server.html
+++ b/front/src/static/config_server.html
@@ -47,7 +47,7 @@
     <div class="form-group pt-1" name="config_server_select_input">
         <label id="config_server_start_udp_server_label" for="config_server_start_udp_server_label" class="text-sm">IP-адрес / Порт</label>
         <div class="input-group flex-nowrap">
-            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_server_start_udp_server_ip_input_field" name="config_server_start_udp_server_ip_input_field" value=''>
+            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_server_start_udp_server_ip_input_field" name="config_server_start_udp_server_ip_input_field" autocomplete="none" value=''>
             <input type="number" class="px-2 form-control form-control-sm" style="width:35% !important" id="config_server_start_udp_server_port_input_field" name="config_server_start_udp_server_port_input_field" min="0" max="65535" value="0">
         </div>
     </div>
@@ -57,7 +57,7 @@
     <div class="form-group pt-1" name="config_server_select_input">
         <label id="config_server_start_tcp_server_label" for="config_server_start_tcp_server_label" class="text-sm">IP-адрес / Порт</label>
         <div class="input-group flex-nowrap">
-            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_server_start_tcp_server_ip_input_field" name="config_server_start_tcp_server_ip_input_field" value=''>
+            <input type="text" class="form-control form-control-sm" style="width:65% !important" id="config_server_start_tcp_server_ip_input_field" name="config_server_start_tcp_server_ip_input_field" autocomplete="none" value=''>
             <input type="number" class="px-2 form-control form-control-sm" style="width:35% !important" id="config_server_start_tcp_server_port_input_field" name="config_server_start_tcp_server_port_input_field" min="0" max="65535" value="0">
         </div>
     </div>
@@ -80,7 +80,7 @@
     </div>
     <label id="config_server_ip_label_example" for="config_server_ip_example" class="text-sm">IP-адрес / Маска</label>
     <div class="input-group pb-2 flex-nowrap">
-        <input type="text" class="form-control form-control-sm w-75" id="config_server_ip_example" name="config_server_ip_example" value=''>
+        <input type="text" class="form-control form-control-sm w-75" id="config_server_ip_example" name="config_server_ip_example" autocomplete="none" value=''>
         <input type="number" class="px-2 form-control form-control-sm w-25" id="config_server_mask_example" name="config_server_mask_example" min="0" max="32" value="0">
     </div>
 </script>


### PR DESCRIPTION
Баг: В яндекс браузере, если элемент имеет два и более полей, рядом с которыми есть слово "адрес" - яндекс предлагает ввести адрес жительства.

Пример с одним полем (автозаполнения нет):
![image](https://github.com/mimi-net/miminet/assets/39369841/b90bf4e4-a498-42aa-9fbb-31ae606ad79a)
Пример с двумя полями (автозаполнение предлагает не то):
![image](https://github.com/mimi-net/miminet/assets/39369841/b8041e69-73de-4869-8206-873271e76112)

Причина бага: Яндекс браузер пытается предсказать то, что нужно подсказать (https://yandex.ru/support/webmaster/for-webmasters/autofill.html)

Решение: выключить автозаполнение

Замечание:
- В **Chrome** и **Yandex browser** я так и не добился того, чтобы он мне предлагал айпи адреса
- В **Edge** сохраняется автозаполнение
![image](https://github.com/mimi-net/miminet/assets/39369841/bcdb672d-6ea2-4e70-9ede-bbaed8fc3f71)

Поэтому решение считаю приемлемым

