### PR TITLE
Fix displaying the VLAN of the shared network

### DIFF
--- a/front/src/static/config.js
+++ b/front/src/static/config.js
@@ -1141,3 +1141,13 @@ const DisableFormInputs = function(){
     let s = config_content_id + ' :input';
     $(s).prop("disabled", true);
 }
+
+const DisableVLANInputs = function(n) {
+    var modalId = 'VlanModal_' + n.data.id;
+
+    $(document).ready(function() {
+        $('#config_button_vlan').prop('disabled', false);
+        $('#' + modalId + ' :input').not('.btn-close').prop('disabled', true);
+        $('#' + modalId + ' .form-check-input, ' + modalId + ' .form-switch input').prop('disabled', true);
+    });
+};  

--- a/front/src/static/netfront_f.js
+++ b/front/src/static/netfront_f.js
@@ -295,6 +295,7 @@ const ShowSwitchConfig = function(n, shared = 0){
 
     if (shared){
         DisableFormInputs();
+        DisableVLANInputs(n);
     }
 }
 


### PR DESCRIPTION
The VLAN button was locked if the network was shared