### PR TITLE
Add network counter for distinct network names

### DIFF
--- a/front/src/miminet_model.py
+++ b/front/src/miminet_model.py
@@ -33,7 +33,7 @@ class User(db.Model, UserMixin):  # type:ignore[name-defined]
     nick = db.Column(Text, nullable=False)
     avatar_uri = db.Column(Text, default="empty.jpg", nullable=False)
 
-    networks_number = db.Column(BigInteger, default=0, nullable=False)
+    network_counter = db.Column(BigInteger, default=0, nullable=False)
 
     vk_id = db.Column(Text, nullable=True)
     google_id = db.Column(Text, nullable=True)

--- a/front/src/miminet_model.py
+++ b/front/src/miminet_model.py
@@ -33,6 +33,8 @@ class User(db.Model, UserMixin):  # type:ignore[name-defined]
     nick = db.Column(Text, nullable=False)
     avatar_uri = db.Column(Text, default="empty.jpg", nullable=False)
 
+    networks_number = db.Column(BigInteger, default=0, nullable=False)
+
     vk_id = db.Column(Text, nullable=True)
     google_id = db.Column(Text, nullable=True)
     yandex_id = db.Column(Text, nullable=True)
@@ -44,7 +46,7 @@ class Network(db.Model):  # type:ignore[name-defined]
     author_id = db.Column(BigInteger, ForeignKey("user.id"), nullable=False)
 
     guid = db.Column(Text, nullable=False, unique=True)
-    title = db.Column(Text, default="Новая сеть", nullable=False)
+    title = db.Column(Text, nullable=False)
 
     description = db.Column(Text, default="", nullable=True)
 

--- a/front/src/miminet_model.py
+++ b/front/src/miminet_model.py
@@ -33,8 +33,6 @@ class User(db.Model, UserMixin):  # type:ignore[name-defined]
     nick = db.Column(Text, nullable=False)
     avatar_uri = db.Column(Text, default="empty.jpg", nullable=False)
 
-    network_counter = db.Column(BigInteger, default=0, nullable=False)
-
     vk_id = db.Column(Text, nullable=True)
     google_id = db.Column(Text, nullable=True)
     yandex_id = db.Column(Text, nullable=True)

--- a/front/src/miminet_network.py
+++ b/front/src/miminet_network.py
@@ -16,7 +16,7 @@ from flask_login import current_user, login_required
 from miminet_config import check_image_with_pil
 from miminet_model import Network, Simulate, db, SimulateLog
 import datetime
-from sqlalchemy import not_
+from sqlalchemy import not_, select, func
 
 
 @login_required
@@ -24,11 +24,14 @@ def create_network():
     user = current_user
     u = uuid.uuid4()
 
-    user.network_counter += 1
-    n = Network(author_id=user.id, title=f"Сеть {user.network_counter}", guid=str(u))
+    network_count = db.session.execute(
+        select(func.count()).select_from(Network).where(Network.author_id == user.id)
+    ).scalar_one()
+    print(network_count)
+
+    n = Network(author_id=user.id, title=f"Сеть {network_count+1}", guid=str(u))
 
     db.session.add(n)
-    db.session.add(user)
     db.session.commit()
 
     return redirect(url_for("web_network", guid=n.guid))

--- a/front/src/miminet_network.py
+++ b/front/src/miminet_network.py
@@ -24,10 +24,11 @@ def create_network():
     user = current_user
     u = uuid.uuid4()
 
-    n = Network(author_id=user.id, guid=str(u))
+    user.networks_number += 1
+    n = Network(author_id=user.id, title=f"Сеть {user.networks_number}", guid=str(u))
+
     db.session.add(n)
-    db.session.flush()
-    db.session.refresh(n)
+    db.session.add(user)
     db.session.commit()
 
     return redirect(url_for("web_network", guid=n.guid))

--- a/front/src/miminet_network.py
+++ b/front/src/miminet_network.py
@@ -24,8 +24,8 @@ def create_network():
     user = current_user
     u = uuid.uuid4()
 
-    user.networks_number += 1
-    n = Network(author_id=user.id, title=f"Сеть {user.networks_number}", guid=str(u))
+    user.network_counter += 1
+    n = Network(author_id=user.id, title=f"Сеть {user.network_counter}", guid=str(u))
 
     db.session.add(n)
     db.session.add(user)


### PR DESCRIPTION
Добавлен **счётчик сетей**, созданных пользователем, добавляемый к названию каждой новой сети (issue #292). При создании сети отправляется запрос в бд и фильтруются сети с тем же author_id, что у пользователя, создающего новую сетью Получаем `network_count`, номер очередной созданной сети будет `network_count + 1`.
- Названия сетей вида `Сеть 1`, `Сеть 2`...`Сеть n`
- При наличии, например, двух сетей (`Сеть 1`, `Сеть 2`) и удалении одной из них, очередная созданнная сеть будет называться `Сеть 2`