### PR TITLE
Fix shared network animation bug

### DIFF
--- a/front/src/static/netfront_f.js
+++ b/front/src/static/netfront_f.js
@@ -2090,7 +2090,7 @@ const SaveAnimationFilters = function () {
     });
 };
 
-const SetPacketFilter = function () {
+const SetPacketFilter = function (shared = 0) {
     // If network player UI is absent (e.g., not on network page), skip.
     if (!document.getElementById("NetworkPlayer") || !document.getElementById("PacketSliderInput")) {
         return;
@@ -2112,7 +2112,11 @@ const SetPacketFilter = function () {
 
     if (packets) {
         FilterPackets();
-        SetNetworkPlayerState(0);
+        if (shared) {
+            SetSharedNetworkPlayerState();
+        } else {
+            SetNetworkPlayerState(0);
+        }
     }
 };
 

--- a/front/src/templates/base.html
+++ b/front/src/templates/base.html
@@ -303,6 +303,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <script>
     window.isAuthenticated = {{ current_user.is_authenticated|tojson }};
+    window.isSharedNetwork = {{ (request.endpoint == 'web_network_shared') | tojson }};
+
+    const shared = window.isSharedNetwork ? 1 : 0
 
     $(document).ready(function() {
         const rawUserConfig = {{ (current_user.config or "null") | tojson }};
@@ -333,7 +336,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         if (typeof UpdateFilterStates === "function") {
             UpdateFilterStates(serverAnimationFilters);
             if (packets) {
-                SetPacketFilter();
+                SetPacketFilter(shared);
             }
         }
 
@@ -348,7 +351,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             UpdateFilterStates(storedFilters);
 
             if (packets) {
-                SetPacketFilter();
+                SetPacketFilter(shared);
             }
         };
 
@@ -376,7 +379,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             network_title = $("#network_title").val();
             network_description = $("#network_description").val();
             UpdateNetworkConfig();
-            SetPacketFilter();
+            SetPacketFilter(shared);
             if (window.isAuthenticated && typeof SaveAnimationFilters === "function") {
                 SaveAnimationFilters();
             }
@@ -390,7 +393,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                 network_title = $("#network_title").val();
                 network_description = $("#network_description").val();
                 UpdateNetworkConfig();
-                SetPacketFilter();
+                SetPacketFilter(shared);
                 if (window.isAuthenticated && typeof SaveAnimationFilters === "function") {
                     SaveAnimationFilters();
                 }


### PR DESCRIPTION
Скрипт в `base.html` вызывал метод `SetPacketFilter`, который вызывал `SetNetworkPlayerState`, который в свою очередь вызывал `DrawGraph` (вместо `SetSharedNetworkPlayerState` и `DrawSharedGraph` соответственно). Это вызывало ошибку в анимации.