### PR TITLE
Update admin page

### DIFF
--- a/front/src/app.py
+++ b/front/src/app.py
@@ -319,17 +319,17 @@ app.register_blueprint(image_routes)
 # Init Flask-admin
 admin = Admin(
     app,
-    index_view=MiminetAdminIndexView(),
+    index_view=MiminetAdminIndexView(name="Обзор"),
     name="Miminet Admin",
 )
 
 
-admin.add_view(TestView(Test, db.session))
-admin.add_view(SectionView(Section, db.session))
-admin.add_view(QuestionView(Question, db.session))
-admin.add_view(AnswerView(Answer, db.session))
-admin.add_view(QuestionCategoryView(QuestionCategory, db.session))
-admin.add_view(SessionQuestionView(SessionQuestion, db.session))
+admin.add_view(TestView(Test, db.session, name="Тесты"))
+admin.add_view(SectionView(Section, db.session, name="Разделы"))
+admin.add_view(QuestionView(Question, db.session, name="Задания"))
+admin.add_view(AnswerView(Answer, db.session, name="Варианты"))
+admin.add_view(QuestionCategoryView(QuestionCategory, db.session, name="Категории"))
+admin.add_view(SessionQuestionView(SessionQuestion, db.session, name="Решения"))
 admin.add_view(
     CreateCheckTaskView(
         Network,

--- a/front/src/app.py
+++ b/front/src/app.py
@@ -1,4 +1,4 @@
-import sys
+﻿import sys
 import os
 from datetime import datetime
 from dotenv import load_dotenv
@@ -28,6 +28,7 @@ from miminet_auth import (
     logout,
     remove_test_user,
     user_profile,
+    user_profile_view,
     vk_callback,
     vk_login,
     yandex_login,
@@ -184,6 +185,7 @@ app.add_url_rule("/auth/yandex_callback", methods=["GET"], view_func=yandex_call
 app.add_url_rule("/auth/tg_callback", methods=["GET"], view_func=tg_callback)
 app.add_url_rule("/user/profile.html", methods=["GET", "POST"], view_func=user_profile)
 app.add_url_rule("/profile", methods=["GET", "POST"], view_func=user_profile)
+app.add_url_rule("/profile/<int:user_id>", methods=["GET"], view_func=user_profile_view)
 app.add_url_rule("/auth/logout", methods=["GET"], view_func=logout)
 
 # Network

--- a/front/src/auth_tests/profile_test.py
+++ b/front/src/auth_tests/profile_test.py
@@ -134,6 +134,7 @@ def test_user_profile_post_without_updates_renders_page(mocker):
         "auth/profile.html", user=user, first_name="", last_name=""
     )
 
+
 def test_user_profile_view_forbidden_without_permission(mocker):
     app = _build_test_app()
 
@@ -182,4 +183,3 @@ def test_google_callback_new_user_without_picture_uses_empty_avatar(mocker):
     assert result == "redirected"
     assert user_ctor.call_args.kwargs["avatar_uri"] == "empty.jpg"
     redirect_next_mock.assert_called_once()
-

--- a/front/src/auth_tests/profile_test.py
+++ b/front/src/auth_tests/profile_test.py
@@ -1,7 +1,9 @@
 import io
 from types import SimpleNamespace
 
+import pytest
 from flask import Flask, session
+from werkzeug.exceptions import Forbidden
 
 import miminet_auth
 
@@ -132,6 +134,15 @@ def test_user_profile_post_without_updates_renders_page(mocker):
         "auth/profile.html", user=user, first_name="", last_name=""
     )
 
+def test_user_profile_view_forbidden_without_permission(mocker):
+    app = _build_test_app()
+
+    mocker.patch("miminet_auth.current_user", SimpleNamespace(id=1, role=0))
+
+    with app.test_request_context("/profile/2", method="GET"):
+        with pytest.raises(Forbidden):
+            miminet_auth.user_profile_view.__wrapped__(2)
+
 
 def test_google_callback_new_user_without_picture_uses_empty_avatar(mocker):
     app = _build_test_app()
@@ -171,3 +182,4 @@ def test_google_callback_new_user_without_picture_uses_empty_avatar(mocker):
     assert result == "redirected"
     assert user_ctor.call_args.kwargs["avatar_uri"] == "empty.jpg"
     redirect_next_mock.assert_called_once()
+

--- a/front/src/miminet_admin.py
+++ b/front/src/miminet_admin.py
@@ -11,6 +11,7 @@ from flask_admin.model import typefmt
 from flask_admin.actions import action
 from flask_login import current_user
 from markupsafe import Markup
+from sqlalchemy.orm import selectinload
 from wtforms import (
     SelectField,
     TextAreaField,
@@ -32,14 +33,92 @@ from quiz.entity.entity import (
     QuestionCategory,
     SessionQuestion,
 )
+from quiz.util.dto import calculate_question_count
 
 ADMIN_ROLE_LEVEL = 1
+
+
+def _pluralize_ru(value, forms):
+    remainder_hundred = value % 100
+    remainder_ten = value % 10
+
+    if 11 <= remainder_hundred <= 14:
+        return forms[2]
+    if remainder_ten == 1:
+        return forms[0]
+    if 2 <= remainder_ten <= 4:
+        return forms[1]
+    return forms[2]
+
+
+def _format_count(value, forms):
+    return f"{value} {_pluralize_ru(value, forms)}"
+
+
+def _build_test_cards(tests):
+    cards = []
+
+    for test in tests:
+        sections = [section for section in test.sections if not section.is_deleted]
+        question_count = sum(calculate_question_count(section) for section in sections)
+        finished_sessions = sum(
+            1
+            for section in sections
+            for session in section.quiz_sessions
+            if not session.is_deleted and session.finished_at is not None
+        )
+        preview_sections = sections[:3]
+
+        cards.append(
+            {
+                "name": test.name,
+                "description": test.description,
+                "status_label": (
+                    "Опубликован" if test.is_ready else "Черновик"
+                ),
+                "retakeable_label": (
+                    "Можно перепроходить"
+                    if test.is_retakeable
+                    else "Одна попытка на раздел"
+                ),
+                "section_label": _format_count(
+                    len(sections), ('раздел', 'раздела', 'разделов')
+                ),
+                "question_label": _format_count(
+                    question_count, ('задание', 'задания', 'заданий')
+                ),
+                "attempts_label": _format_count(
+                    finished_sessions,
+                    (
+                        'завершенное прохождение',
+                        'завершенных прохождения',
+                        'завершенных прохождений',
+                    ),
+                ),
+                "section_names": [section.name for section in preview_sections],
+                "hidden_section_count": max(len(sections) - len(preview_sections), 0),
+            }
+        )
+
+    return cards
 
 
 class MiminetAdminIndexView(AdminIndexView):
     @expose("/")
     def index(self):
-        return self.render("admin/index.html")
+        tests = (
+            Test.query.filter(
+                Test.created_by_id == current_user.id,
+                Test.is_deleted.is_(False),
+            )
+            .options(
+                selectinload(Test.sections).selectinload(Section.quiz_sessions),
+                selectinload(Test.sections).selectinload(Section.questions),
+            )
+            .order_by(Test.created_on.desc())
+            .all()
+        )
+        return self.render("admin/index.html", test_cards=_build_test_cards(tests))
 
     def is_accessible(self):
         if current_user.is_authenticated:

--- a/front/src/miminet_admin.py
+++ b/front/src/miminet_admin.py
@@ -11,6 +11,7 @@ from flask_admin.model import typefmt
 from flask_admin.actions import action
 from flask_login import current_user
 from markupsafe import Markup
+from sqlalchemy import func
 from sqlalchemy.orm import selectinload
 from wtforms import (
     SelectField,
@@ -31,6 +32,7 @@ from quiz.entity.entity import (
     Section,
     Question,
     QuestionCategory,
+    QuizSession,
     SessionQuestion,
 )
 from quiz.util.dto import calculate_question_count
@@ -103,22 +105,203 @@ def _build_test_cards(tests):
     return cards
 
 
+def _get_admin_tests(user_id):
+    return (
+        Test.query.filter(
+            Test.created_by_id == user_id,
+            Test.is_deleted.is_(False),
+        )
+        .options(
+            selectinload(Test.sections).selectinload(Section.quiz_sessions),
+            selectinload(Test.sections).selectinload(Section.questions),
+        )
+        .order_by(Test.created_on.desc())
+        .all()
+    )
+
+
+def _calculate_session_score(quiz_session):
+    score = 0
+    max_score = 0
+
+    for session_question in quiz_session.sessions:
+        if session_question.is_deleted:
+            continue
+
+        question = session_question.question
+        is_practice = question is not None and question.question_type == 0
+
+        if is_practice:
+            score += session_question.score or 0
+            max_score += session_question.max_score or 0
+        else:
+            score += 1 if session_question.is_correct else 0
+            max_score += 1
+
+    return score, max_score
+
+
+def _build_statistics_groups(section_columns):
+    groups = []
+
+    for section in section_columns:
+        if not groups or groups[-1]["test_id"] != section["test_id"]:
+            groups.append(
+                {
+                    "test_id": section["test_id"],
+                    "test_name": section["test_name"],
+                    "colspan": 1,
+                }
+            )
+        else:
+            groups[-1]["colspan"] += 1
+
+    return groups
+
+
+def _build_statistics_data(tests):
+    section_columns = []
+
+    for test in tests:
+        sections = [section for section in test.sections if not section.is_deleted]
+        sections.sort(key=lambda section: section.id or 0)
+
+        for section in sections:
+            section_columns.append(
+                {
+                    "id": section.id,
+                    "test_id": test.id,
+                    "test_name": test.name,
+                    "section_name": section.name,
+                }
+            )
+
+    if not section_columns:
+        return section_columns, []
+
+    section_ids = [section["id"] for section in section_columns]
+    latest_sessions_subquery = (
+        db.session.query(
+            QuizSession.id.label("session_id"),
+            func.row_number()
+            .over(
+                partition_by=(QuizSession.created_by_id, QuizSession.section_id),
+                order_by=(QuizSession.finished_at.desc(), QuizSession.id.desc()),
+            )
+            .label("row_num"),
+        )
+        .filter(
+            QuizSession.section_id.in_(section_ids),
+            QuizSession.is_deleted.is_(False),
+            QuizSession.finished_at.isnot(None),
+            QuizSession.created_by_id.isnot(None),
+        )
+        .subquery()
+    )
+
+    sessions = (
+        db.session.query(QuizSession)
+        .join(
+            latest_sessions_subquery,
+            latest_sessions_subquery.c.session_id == QuizSession.id,
+        )
+        .filter(latest_sessions_subquery.c.row_num == 1)
+        .options(
+            selectinload(QuizSession.sessions).selectinload(SessionQuestion.question),
+            selectinload(QuizSession.created_by_user),
+        )
+        .all()
+    )
+
+    latest_session_by_user_section = {}
+    users_by_id = {}
+
+    for session in sessions:
+        key = (session.created_by_id, session.section_id)
+        if key in latest_session_by_user_section:
+            continue
+
+        latest_session_by_user_section[key] = session
+        users_by_id[session.created_by_id] = session.created_by_user
+
+    rows = []
+
+    for user_id, user in users_by_id.items():
+        cells = []
+        total_score = 0
+        completed_sections = 0
+
+        for section in section_columns:
+            session = latest_session_by_user_section.get((user_id, section["id"]))
+
+            if session is None:
+                cells.append({"has_result": False})
+                continue
+
+            score, max_score = _calculate_session_score(session)
+            total_score += score
+            completed_sections += 1
+            cells.append(
+                {
+                    "has_result": True,
+                    "score": score,
+                    "max_score": max_score,
+                    "guid": session.guid,
+                }
+            )
+
+        if user and user.nick:
+            user_name = user.nick
+        elif user and user.email:
+            user_name = user.email
+        else:
+            user_name = f"Пользователь {user_id}"
+
+        rows.append(
+            {
+                "user_id": user_id,
+                "user_name": user_name,
+                "can_open_profile": user is not None,
+                "total_score": total_score,
+                "completed_sections": completed_sections,
+                "cells": cells,
+            }
+        )
+
+    rows.sort(
+        key=lambda row: (
+            -row["total_score"],
+            -row["completed_sections"],
+            row["user_name"].casefold(),
+        )
+    )
+
+    for position, row in enumerate(rows, start=1):
+        row["position"] = position
+
+    return section_columns, rows
+
+
 class MiminetAdminIndexView(AdminIndexView):
     @expose("/")
     def index(self):
-        tests = (
-            Test.query.filter(
-                Test.created_by_id == current_user.id,
-                Test.is_deleted.is_(False),
-            )
-            .options(
-                selectinload(Test.sections).selectinload(Section.quiz_sessions),
-                selectinload(Test.sections).selectinload(Section.questions),
-            )
-            .order_by(Test.created_on.desc())
-            .all()
+        tests = _get_admin_tests(current_user.id)
+        return self.render(
+            "admin/index.html",
+            test_cards=_build_test_cards(tests),
+            statistics_url=url_for("admin.statistics"),
         )
-        return self.render("admin/index.html", test_cards=_build_test_cards(tests))
+
+    @expose("/statistics")
+    def statistics(self):
+        tests = _get_admin_tests(current_user.id)
+        section_columns, user_rows = _build_statistics_data(tests)
+        return self.render(
+            "admin/statistics.html",
+            section_columns=section_columns,
+            test_groups=_build_statistics_groups(section_columns),
+            user_rows=user_rows,
+        )
 
     def is_accessible(self):
         if current_user.is_authenticated:
@@ -601,3 +784,4 @@ class CreateCheckTaskView(MiminetAdminModelView):
                 flash(f"Ошибка: {str(e)}", "error")
 
         return self.render("admin/create_check_task.html", form=form)
+

--- a/front/src/miminet_admin.py
+++ b/front/src/miminet_admin.py
@@ -75,26 +75,24 @@ def _build_test_cards(tests):
             {
                 "name": test.name,
                 "description": test.description,
-                "status_label": (
-                    "Опубликован" if test.is_ready else "Черновик"
-                ),
+                "status_label": ("Опубликован" if test.is_ready else "Черновик"),
                 "retakeable_label": (
                     "Можно перепроходить"
                     if test.is_retakeable
                     else "Одна попытка на раздел"
                 ),
                 "section_label": _format_count(
-                    len(sections), ('раздел', 'раздела', 'разделов')
+                    len(sections), ("раздел", "раздела", "разделов")
                 ),
                 "question_label": _format_count(
-                    question_count, ('задание', 'задания', 'заданий')
+                    question_count, ("задание", "задания", "заданий")
                 ),
                 "attempts_label": _format_count(
                     finished_sessions,
                     (
-                        'завершенное прохождение',
-                        'завершенных прохождения',
-                        'завершенных прохождений',
+                        "завершенное прохождение",
+                        "завершенных прохождения",
+                        "завершенных прохождений",
                     ),
                 ),
                 "section_names": [section.name for section in preview_sections],
@@ -784,4 +782,3 @@ class CreateCheckTaskView(MiminetAdminModelView):
                 flash(f"Ошибка: {str(e)}", "error")
 
         return self.render("admin/create_check_task.html", form=form)
-

--- a/front/src/miminet_auth.py
+++ b/front/src/miminet_auth.py
@@ -9,7 +9,7 @@ import hashlib
 
 import google.auth.transport.requests
 import requests
-from flask import flash, redirect, render_template, request, session, url_for, jsonify
+from flask import flash, redirect, render_template, request, session, url_for, jsonify, abort
 from flask_login import (
     LoginManager,
     current_user,
@@ -38,6 +38,7 @@ DEFAULT_USER_CONFIG = {
 AVATAR_UPLOAD_FOLDER = "/app/static/avatar"
 ALLOWED_EXTENSIONS = {"bmp", "png", "jpg", "jpeg"}
 MAX_AVATAR_SIZE = 1 * 1024 * 1024
+PROFILE_VIEWER_MIN_ROLE = 1
 
 login_manager = LoginManager()
 login_manager.login_view = "login_index"
@@ -278,6 +279,26 @@ def user_profile():
         "auth/profile.html", user=user, first_name=first_name, last_name=last_name
     )
 
+
+@login_required
+def user_profile_view(user_id: int):
+    if current_user.id != user_id and (current_user.role or 0) < PROFILE_VIEWER_MIN_ROLE:
+        abort(403)
+
+    user = User.query.filter_by(id=user_id).first()
+    if user is None:
+        abort(404)
+
+    nick_parts = (user.nick or "").strip().split(maxsplit=1)
+    first_name = nick_parts[0] if nick_parts else ""
+    last_name = nick_parts[1] if len(nick_parts) > 1 else ""
+
+    return render_template(
+        "auth/profile_readonly.html",
+        user=user,
+        first_name=first_name,
+        last_name=last_name,
+    )
 
 def _load_user_config(user: User) -> dict:
     try:

--- a/front/src/miminet_auth.py
+++ b/front/src/miminet_auth.py
@@ -9,7 +9,16 @@ import hashlib
 
 import google.auth.transport.requests
 import requests
-from flask import flash, redirect, render_template, request, session, url_for, jsonify, abort
+from flask import (
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+    jsonify,
+    abort,
+)
 from flask_login import (
     LoginManager,
     current_user,
@@ -282,7 +291,10 @@ def user_profile():
 
 @login_required
 def user_profile_view(user_id: int):
-    if current_user.id != user_id and (current_user.role or 0) < PROFILE_VIEWER_MIN_ROLE:
+    if (
+        current_user.id != user_id
+        and (current_user.role or 0) < PROFILE_VIEWER_MIN_ROLE
+    ):
         abort(403)
 
     user = User.query.filter_by(id=user_id).first()
@@ -299,6 +311,7 @@ def user_profile_view(user_id: int):
         first_name=first_name,
         last_name=last_name,
     )
+
 
 def _load_user_config(user: User) -> dict:
     try:

--- a/front/src/templates/admin/index.html
+++ b/front/src/templates/admin/index.html
@@ -47,7 +47,7 @@
         font-weight: 600;
         text-decoration: none;
         box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
-        cursor: default;
+        cursor: pointer;
     }
 
     .admin-results__stats-link:hover,
@@ -204,7 +204,7 @@
                 заданий и количество завершенных прохождений.
             </p>
         </div>
-        <a href="#" class="admin-results__stats-link" onclick="return false;">Статистика</a>
+        <a href="{{ statistics_url }}" class="admin-results__stats-link">Статистика</a>
     </div>
 
     {% if test_cards %}

--- a/front/src/templates/admin/index.html
+++ b/front/src/templates/admin/index.html
@@ -1,5 +1,252 @@
 {% extends 'admin/master.html' %}
 
 {% block body %}
+<style>
+    .admin-results {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 32px 18px 48px;
+        color: #202733;
+    }
 
+    .admin-results__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+        margin-bottom: 28px;
+    }
+
+    .admin-results__title {
+        margin: 0;
+        font-size: 36px;
+        font-weight: 700;
+        line-height: 1.1;
+        color: #18202c;
+    }
+
+    .admin-results__subtitle {
+        margin: 10px 0 0;
+        max-width: 700px;
+        color: #6b7280;
+        font-size: 15px;
+        line-height: 1.5;
+    }
+
+    .admin-results__stats-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 42px;
+        padding: 0 18px;
+        border: 1px solid #d6dce5;
+        border-radius: 10px;
+        background: #ffffff;
+        color: #364152;
+        font-size: 14px;
+        font-weight: 600;
+        text-decoration: none;
+        box-shadow: 0 10px 28px rgba(15, 23, 42, 0.06);
+        cursor: default;
+    }
+
+    .admin-results__stats-link:hover,
+    .admin-results__stats-link:focus {
+        color: #364152;
+        text-decoration: none;
+    }
+
+    .admin-results__list {
+        display: flex;
+        flex-direction: column;
+        gap: 18px;
+    }
+
+    .admin-results__card {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 24px;
+        padding: 26px 28px;
+        border-radius: 18px;
+        border: 1px solid #edf1f6;
+        background: #ffffff;
+        box-shadow: 0 16px 38px rgba(15, 23, 42, 0.07);
+    }
+
+    .admin-results__main {
+        min-width: 0;
+        flex: 1 1 auto;
+    }
+
+    .admin-results__badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 14px;
+    }
+
+    .admin-results__badge {
+        display: inline-flex;
+        align-items: center;
+        min-height: 28px;
+        padding: 0 12px;
+        border-radius: 999px;
+        background: #eef3ff;
+        color: #3851a6;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.01em;
+    }
+
+    .admin-results__badge--muted {
+        background: #f4f6f8;
+        color: #5b6676;
+    }
+
+    .admin-results__name {
+        margin: 0 0 10px;
+        font-size: 30px;
+        font-weight: 700;
+        line-height: 1.18;
+        color: #18202c;
+    }
+
+    .admin-results__description {
+        margin: 0;
+        color: #667085;
+        font-size: 15px;
+        line-height: 1.6;
+        max-width: 760px;
+    }
+
+    .admin-results__sections {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 18px;
+    }
+
+    .admin-results__section-pill {
+        display: inline-flex;
+        align-items: center;
+        min-height: 32px;
+        padding: 0 14px;
+        border-radius: 999px;
+        background: #f6f8fb;
+        color: #415062;
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .admin-results__footer {
+        margin-top: 18px;
+        color: #667085;
+        font-size: 14px;
+        font-weight: 600;
+    }
+
+    .admin-results__meta {
+        min-width: 220px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 10px;
+        padding-top: 6px;
+    }
+
+    .admin-results__meta-item {
+        color: #5f6b7a;
+        font-size: 16px;
+        font-weight: 600;
+        text-align: right;
+    }
+
+    .admin-results__empty {
+        padding: 42px 28px;
+        border-radius: 18px;
+        border: 1px dashed #d9e1ea;
+        background: #fbfcfe;
+        color: #667085;
+        font-size: 16px;
+        line-height: 1.6;
+    }
+
+    @media (max-width: 900px) {
+        .admin-results__header,
+        .admin-results__card {
+            flex-direction: column;
+        }
+
+        .admin-results__stats-link {
+            width: 100%;
+        }
+
+        .admin-results__meta {
+            min-width: 0;
+            width: 100%;
+            align-items: flex-start;
+            padding-top: 0;
+        }
+
+        .admin-results__meta-item {
+            text-align: left;
+        }
+    }
+</style>
+
+<div class="admin-results">
+    <div class="admin-results__header">
+        <div>
+            <h1 class="admin-results__title">Мои тесты</h1>
+            <p class="admin-results__subtitle">
+                Здесь собраны созданные вами тесты. Для каждого теста показываем число разделов,
+                заданий и количество завершенных прохождений.
+            </p>
+        </div>
+        <a href="#" class="admin-results__stats-link" onclick="return false;">Статистика</a>
+    </div>
+
+    {% if test_cards %}
+        <div class="admin-results__list">
+            {% for test in test_cards %}
+                <article class="admin-results__card">
+                    <div class="admin-results__main">
+                        <div class="admin-results__badges">
+                            <span class="admin-results__badge">{{ test.status_label }}</span>
+                            <span class="admin-results__badge admin-results__badge--muted">{{ test.retakeable_label }}</span>
+                        </div>
+
+                        <h2 class="admin-results__name">{{ test.name }}</h2>
+                        <p class="admin-results__description">
+                            {{ test.description or 'Описание пока не добавлено.' }}
+                        </p>
+
+                        {% if test.section_names %}
+                            <div class="admin-results__sections">
+                                {% for section_name in test.section_names %}
+                                    <span class="admin-results__section-pill">{{ section_name }}</span>
+                                {% endfor %}
+                                {% if test.hidden_section_count %}
+                                    <span class="admin-results__section-pill">+{{ test.hidden_section_count }}</span>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+
+                        <div class="admin-results__footer">{{ test.attempts_label }}</div>
+                    </div>
+
+                    <div class="admin-results__meta">
+                        <div class="admin-results__meta-item">{{ test.section_label }}</div>
+                        <div class="admin-results__meta-item">{{ test.question_label }}</div>
+                    </div>
+                </article>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="admin-results__empty">
+            Пока нет созданных тестов. Когда появятся тесты и разделы, здесь будет их краткая сводка.
+        </div>
+    {% endif %}
+</div>
 {% endblock %}

--- a/front/src/templates/admin/statistics.html
+++ b/front/src/templates/admin/statistics.html
@@ -214,7 +214,16 @@
                         <tr>
                             <td>{{ row.position }}</td>
                             <td class="admin-stats__user">
-                                <span>{{ row.user_name }}</span>
+                                {% if row.can_open_profile %}
+                                    <a
+                                        href="{{ url_for('user_profile_view', user_id=row.user_id) }}"
+                                        class="admin-stats__user-link"
+                                    >
+                                        {{ row.user_name }}
+                                    </a>
+                                {% else %}
+                                    <span>{{ row.user_name }}</span>
+                                {% endif %}
                             </td>
                             <td>{{ row.total_score }}</td>
                             {% for cell in row.cells %}

--- a/front/src/templates/admin/statistics.html
+++ b/front/src/templates/admin/statistics.html
@@ -1,0 +1,249 @@
+{% extends 'admin/master.html' %}
+
+{% block body %}
+<style>
+    .admin-stats {
+        max-width: 1320px;
+        margin: 0 auto;
+        padding: 30px 18px 48px;
+        color: #202733;
+    }
+
+    .admin-stats__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 16px;
+        margin-bottom: 22px;
+    }
+
+    .admin-stats__title {
+        margin: 0;
+        font-size: 34px;
+        font-weight: 700;
+        line-height: 1.15;
+        color: #18202c;
+    }
+
+    .admin-stats__subtitle {
+        margin: 10px 0 0;
+        color: #6b7280;
+        font-size: 14px;
+        line-height: 1.55;
+        max-width: 860px;
+    }
+
+
+    .admin-stats__table-wrap {
+        border: 1px solid #d9e2ed;
+        border-radius: 14px;
+        background: #ffffff;
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+        overflow-x: auto;
+    }
+
+    .admin-stats__table {
+        width: 100%;
+        min-width: 1080px;
+        border-collapse: collapse;
+        table-layout: fixed;
+    }
+
+    .admin-stats__table thead th,
+    .admin-stats__table tbody td {
+        border-right: 1px solid #dfe6f0;
+    }
+
+    .admin-stats__table thead th:last-child,
+    .admin-stats__table tbody td:last-child {
+        border-right: none;
+    }
+
+    .admin-stats__table thead th {
+        background: #f7fafc;
+        color: #334155;
+        font-size: 13px;
+        font-weight: 700;
+        text-align: center;
+        padding: 10px 8px;
+    }
+
+    .admin-stats__table thead tr:first-child th {
+        border-bottom: 1px solid #dfe6f0;
+        vertical-align: middle;
+        min-height: 54px;
+    }
+
+    .admin-stats__table thead tr:last-child th {
+        border-bottom: 1px solid #dfe6f0;
+        background: #fbfdff;
+        color: #3f4f66;
+        font-size: 12px;
+        font-weight: 700;
+        min-height: 44px;
+    }
+
+    .admin-stats__table tbody td {
+        border-bottom: 1px solid #edf1f6;
+        color: #1f2937;
+        font-size: 14px;
+        text-align: center;
+        padding: 10px 8px;
+    }
+
+    .admin-stats__table tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    .admin-stats__table th:first-child,
+    .admin-stats__table td:first-child {
+        width: 52px;
+    }
+
+    .admin-stats__table th:nth-child(2),
+    .admin-stats__table td:nth-child(2) {
+        width: 220px;
+        text-align: left;
+    }
+
+    .admin-stats__table th:nth-child(3),
+    .admin-stats__table td:nth-child(3) {
+        width: 90px;
+    }
+
+    .admin-stats__test-head {
+        color: #2f5ecf;
+        font-size: 16px;
+        font-weight: 700;
+        line-height: 1.25;
+        word-break: break-word;
+    }
+
+    .admin-stats__section-head {
+        color: #42618c;
+        font-size: 12px;
+        font-weight: 700;
+        line-height: 1.2;
+        word-break: break-word;
+    }
+
+    .admin-stats__user {
+        color: #111827;
+        font-weight: 600;
+    }
+
+    .admin-stats__user-link {
+        color: #3558d5;
+        text-decoration: none;
+        font-weight: 600;
+    }
+
+    .admin-stats__user-link:hover,
+    .admin-stats__user-link:focus {
+        color: #2447c8;
+        text-decoration: underline;
+    }
+
+    .admin-stats__score-link {
+        color: #3558d5;
+        font-weight: 700;
+        text-decoration: none;
+    }
+
+    .admin-stats__score-link:hover,
+    .admin-stats__score-link:focus {
+        color: #2447c8;
+        text-decoration: underline;
+    }
+
+    .admin-stats__empty-cell {
+        color: #9aa3b2;
+    }
+
+    .admin-stats__empty {
+        padding: 32px 24px;
+        border-radius: 14px;
+        border: 1px dashed #d9e1ea;
+        background: #fbfcfe;
+        color: #667085;
+        font-size: 15px;
+        line-height: 1.6;
+    }
+
+    @media (max-width: 900px) {
+        .admin-stats__header {
+            flex-direction: column;
+        }
+
+    }
+</style>
+
+<div class="admin-stats">
+    <div class="admin-stats__header">
+        <div>
+            <h1 class="admin-stats__title">Статистика по разделам</h1>
+            <p class="admin-stats__subtitle">
+                Сверху указаны тесты, ниже их разделы. Нажмите на результат,
+                чтобы открыть попытку.
+            </p>
+        </div>
+    </div>
+
+    {% if section_columns and user_rows %}
+        <div class="admin-stats__table-wrap">
+            <table class="admin-stats__table">
+                <thead>
+                    <tr>
+                        <th rowspan="2">№</th>
+                        <th rowspan="2">Пользователь</th>
+                        <th rowspan="2">Итог</th>
+                        {% for group in test_groups %}
+                            <th colspan="{{ group.colspan }}" class="admin-stats__test-head">
+                                {{ group.test_name }}
+                            </th>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        {% for section in section_columns %}
+                            <th class="admin-stats__section-head">{{ section.section_name }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in user_rows %}
+                        <tr>
+                            <td>{{ row.position }}</td>
+                            <td class="admin-stats__user">
+                                <span>{{ row.user_name }}</span>
+                            </td>
+                            <td>{{ row.total_score }}</td>
+                            {% for cell in row.cells %}
+                                <td>
+                                    {% if cell.has_result %}
+                                        <a
+                                            href="{{ url_for('get_result_by_session_guid_endpoint', guid=cell.guid) }}"
+                                            class="admin-stats__score-link"
+                                        >
+                                            {{ cell.score }}/{{ cell.max_score }}
+                                        </a>
+                                    {% else %}
+                                        <span class="admin-stats__empty-cell">—</span>
+                                    {% endif %}
+                                </td>
+                            {% endfor %}
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% elif section_columns %}
+        <div class="admin-stats__empty">
+            По вашим разделам пока нет завершенных прохождений.
+        </div>
+    {% else %}
+        <div class="admin-stats__empty">
+            Пока нет разделов для отображения статистики.
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/front/src/templates/auth/profile_readonly.html
+++ b/front/src/templates/auth/profile_readonly.html
@@ -1,0 +1,135 @@
+{% extends "base.html" %}
+
+{% block title %}Профиль пользователя{% endblock %}
+
+{% block content %}
+<div class="container py-5 mt-5">
+  {% set vk_link = 'https://vk.com/id' ~ user.vk_id if user.vk_id else '' %}
+  {% set google_link = 'https://myaccount.google.com/' if user.google_id else '' %}
+  {% set yandex_link = 'https://id.yandex.ru/' if user.yandex_id else '' %}
+  {% set tg_link = 'tg://user?id=' ~ user.tg_id if user.tg_id else '' %}
+
+  <div class="row g-4 align-items-start">
+    <div class="col-12 col-lg-3">
+      <div class="text-center pe-lg-3">
+        <div style="width: 180px; height: 180px; border-radius: 50%; overflow: hidden; margin: 0 auto 1rem;">
+          <img
+            src="{{ url_for('static', filename='avatar/' + user.avatar_uri) }}"
+            alt="Аватар пользователя"
+            style="width: 100%; height: 100%; object-fit: cover;"
+          >
+        </div>
+
+        <h2 class="h4 mb-0">
+          {{ first_name }}{% if last_name %} {{ last_name }}{% endif %}
+        </h2>
+        <p class="text-muted small mt-2 mb-0">Режим просмотра профиля</p>
+      </div>
+    </div>
+
+    <div class="col-12 col-lg-8">
+      <div class="ps-lg-4 border-start">
+        <h1 class="mb-4">Профиль пользователя</h1>
+
+        <div class="pb-4 border-bottom">
+          <h5 class="text-primary mb-3">Основная информация</h5>
+
+          <div class="row g-3">
+            <div class="col-12 col-md-6">
+              <label class="form-label">Имя</label>
+              <input type="text" class="form-control form-control-lg" value="{{ first_name }}" readonly>
+            </div>
+
+            <div class="col-12 col-md-6">
+              <label class="form-label">Фамилия</label>
+              <input type="text" class="form-control form-control-lg" value="{{ last_name }}" readonly>
+            </div>
+          </div>
+        </div>
+
+        <div class="pt-4">
+          <h5 class="text-primary mb-3">Контакты</h5>
+
+          <div class="row g-3">
+            <div class="col-12 col-md-6">
+              <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                  <div class="d-flex align-items-center gap-3">
+                    <span class="btn btn-secondary btn-vk btn-icon flex-shrink-0" style="width: 52px; height: 52px;" aria-hidden="true">
+                      <i class="bx bxl-vk"></i>
+                    </span>
+                    <div class="w-100">
+                      {% if vk_link %}
+                        <a href="{{ vk_link }}" target="_blank" rel="noopener" class="form-control text-decoration-none">{{ vk_link }}</a>
+                      {% else %}
+                        <input class="form-control" readonly value="VK не привязан">
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-12 col-md-6">
+              <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                  <div class="d-flex align-items-center gap-3">
+                    <span class="btn btn-secondary btn-google btn-icon flex-shrink-0" style="width: 52px; height: 52px;" aria-hidden="true">
+                      <i class="bx bxl-google"></i>
+                    </span>
+                    <div class="w-100">
+                      {% if google_link %}
+                        <a href="{{ google_link }}" target="_blank" rel="noopener" class="form-control text-decoration-none">{{ google_link }}</a>
+                      {% else %}
+                        <input class="form-control" readonly value="Google не привязан">
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-12 col-md-6">
+              <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                  <div class="d-flex align-items-center gap-3">
+                    <span class="btn btn-secondary btn-yandex btn-icon flex-shrink-0" style="width: 52px; height: 52px;" aria-hidden="true">
+                      <img src="{{ url_for('static', filename='images/yandex_icon.png') }}" style="width: 24px; height: 24px;" alt="Yandex">
+                    </span>
+                    <div class="w-100">
+                      {% if yandex_link %}
+                        <a href="{{ yandex_link }}" target="_blank" rel="noopener" class="form-control text-decoration-none">{{ yandex_link }}</a>
+                      {% else %}
+                        <input class="form-control" readonly value="Yandex не привязан">
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-12 col-md-6">
+              <div class="card h-100 shadow-sm border-0">
+                <div class="card-body">
+                  <div class="d-flex align-items-center gap-3">
+                    <span class="btn btn-secondary btn-telegram btn-icon flex-shrink-0" style="width: 52px; height: 52px;" aria-hidden="true">
+                      <i class="bx bxl-telegram"></i>
+                    </span>
+                    <div class="w-100">
+                      {% if tg_link %}
+                        <a href="{{ tg_link }}" class="form-control text-decoration-none">{{ tg_link }}</a>
+                      {% else %}
+                        <input class="form-control" readonly value="Telegram не привязан">
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Что сделано

- Обновлена главная страница Flask-Admin: теперь это обзор "Мои тесты" со сводкой по тестам текущего администратора
- Для каждого теста показываются статус, режим перепрохождения, количество разделов, заданий и завершенных прохождений
- Добавлена страница статистики по разделам с таблицей результатов пользователей и переходом в конкретную попытку
- Добавлен read-only просмотр профиля пользователя по `/profile/<user_id>` с переходом из таблицы статистики
- Интерфейс админки переведен на русские названия разделов

<img width="1904" height="952" alt="image" src="https://github.com/user-attachments/assets/b41b33d3-af96-425a-8385-064fbf158510" />
<img width="1505" height="948" alt="image" src="https://github.com/user-attachments/assets/8f200fcc-9f63-41e9-a89a-7ace657edb5e" />

