### PR TITLE
Init процесс в celery контейнере

### DIFF
--- a/back/docker-compose.yml
+++ b/back/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 
 services:
   miminet:
+    init: true
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -15,4 +16,3 @@ services:
       - queue_names=${queue_names}
     command: celery -A app.celery worker --loglevel=info
     privileged: true
-


### PR DESCRIPTION
mn -c в [emulator.py](https://github.com/mimi-net/miminet/blob/3f895540a8e35e42de03d658204ff2bae9dc976a/back/src/emulator.py#L129) каждый раз порождает 4 зомби процесса, которые остаются сиротами и не подчищаются из-за отсутствия init процесса в контейнере.

fixes #307 