### PR TITLE
Удалил parallax с главной страницы

### DIFF
--- a/front/src/templates/index.html
+++ b/front/src/templates/index.html
@@ -183,7 +183,7 @@
 				 </div>
 			 </div>
 
-			 <div class="col-md-6 offset-lg-1 order-md-2 order-1 rellax" data-rellax-percentage="0.5" data-rellax-speed="0.5" data-disable-parallax-down="md">
+			 <div class="col-md-6 offset-lg-1 order-md-2 order-1">
 
 				 <div class="bg-secondary rounded-3">
 					 <img src="/images/lecture.png" alt="Lecture image" class="d-block">
@@ -193,7 +193,7 @@
 
 		 <div class="row gy-4 pb-xl-5 pb-md-4 pb-3">
 
-			 <div class="col-md-6 offset-lg-1 order-md-2 order-1 rellax" data-rellax-percentage="0.5" data-rellax-speed="0.5" data-disable-parallax-down="md">
+			 <div class="col-md-6 offset-lg-1 order-md-2 order-1">
 
 				 <div class="bg-secondary rounded-3">
 					 <img src="/images/practice.png" alt="Practice image" class="d-block">
@@ -232,7 +232,7 @@
 				 </div>
 			 </div>
 
-			 <div class="col-md-6 offset-lg-1 order-md-2 order-1 rellax" data-rellax-percentage="0.5" data-rellax-speed="0.5" data-disable-parallax-down="md">
+			 <div class="col-md-6 offset-lg-1 order-md-2 order-1">
 				 <div class="bg-secondary rounded-3">
 					 <img src="/images/test.png" alt="Test image" class="d-block">
 				 </div>
@@ -249,10 +249,10 @@
               <div class="step-number-inner">1</div>
             </div>
             <div class="step-body d-flex align-items-center ps-xl-5">
-              <div class="rellax d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5" data-rellax-percentage="0.5" data-rellax-speed="-0.3" data-disable-parallax-down="lg">
+              <div class="d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5">
                 <img src="/images/howto/how_to_1.png" width="250" alt="Нарисуйте свою сеть">
               </div>
-              <div class="rellax ps-md-4 ps-xl-5" data-rellax-percentage="0.5" data-rellax-speed="0.4" data-disable-parallax-down="lg">
+              <div class="ps-md-4 ps-xl-5">
                 <h3 class="h4">Нарисуйте свою сеть</h3>
                 <p class="mb-0">Вы можете создать компьютерную сеть, в которой будут хосты, свитчи, хабы, раутеры и сервера. Также можете задать настройки для каждого устройства.</p>
               </div>
@@ -263,10 +263,10 @@
               <div class="step-number-inner">2</div>
             </div>
             <div class="step-body d-flex align-items-center ps-xl-5">
-              <div class="rellax d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5" data-rellax-percentage="0.5" data-rellax-speed="-0.5" data-disable-parallax-down="lg">
+              <div class="d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5">
                 <img src="/images/howto/how_to_2.png" width="250" alt="Отправте сеть на эмуляцию">
               </div>
-              <div class="rellax ps-md-4 ps-xl-5" data-rellax-percentage="0.5" data-rellax-speed="0.5" data-disable-parallax-down="lg">
+              <div class="ps-md-4 ps-xl-5">
                 <h3 class="h4">Отправьте сеть на эмуляцию</h3>
                 <p class="mb-0">На нашем сервере ваша сеть будет эмулироваться с помощью сетевой подсистемы Linux. Для каждого устройства создается сетевой интерфейс со своим уникальным MAC адресом и другими настройками.</p>
               </div>
@@ -277,10 +277,10 @@
               <div class="step-number-inner">3</div>
             </div>
             <div class="step-body d-flex align-items-center ps-xl-5">
-              <div class="rellax d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5" data-rellax-percentage="0.5" data-rellax-speed="-0.3" data-disable-parallax-down="lg">
+              <div class="d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5">
                 <img src="/images/howto/how_to_3.png" class="d-dark-mode-none" width="250" alt="Illustration">
               </div>
-              <div class="rellax ps-md-4 ps-xl-5" data-rellax-percentage="0.5" data-rellax-speed="0.4" data-disable-parallax-down="lg">
+              <div class="ps-md-4 ps-xl-5">
                 <h3 class="h4">Дождитесь эмуляции на сервере</h3>
                 <p class="mb-0">Во время эмуляции сети идет захват всего сетевого трафика, который затем обрабатывается для визуализации.</p>
               </div>
@@ -291,10 +291,10 @@
               <div class="step-number-inner">4</div>
             </div>
             <div class="step-body d-flex align-items-center ps-xl-5">
-              <div class="rellax d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5" data-rellax-percentage="0.5" data-rellax-speed="-0.5" data-disable-parallax-down="lg">
+              <div class="d-none d-lg-block flex-shrink-0 mx-4 mx-xl-5">
                 <img src="/images/howto/how_to_4.png" class="d-dark-mode-none" width="250" alt="Illustration">
               </div>
-              <div class="rellax ps-md-4 ps-xl-5" data-rellax-percentage="0.5" data-rellax-speed="0.6" data-disable-parallax-down="lg">
+              <div class="ps-md-4 ps-xl-5">
                 <h3 class="h4">Запустите анимацию</h3>
                 <p class="mb-0">Запустите анимацию и наблюдайте за сетевым трафиком в удобном формате.</p>
               </div>


### PR DESCRIPTION
Удалил parallax-скроллинг с главной страницы, из-за которого едут картинки относительно остальных элементов и перекрывают надписи

fixes #415 