### PR TITLE
Enable rootless local development for frontend and backend tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,161 @@
+# DEVELOPMENT.md — Run tests locally without Docker
+
+This document covers running Miminet tests on a rootless Linux host
+using **podman** (or docker) and **uv**. The production deployment
+with Docker Compose is described in `README.md`.
+
+## Prerequisites
+
+- Linux with podman 6+ (or docker)
+- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- ~4 GB free disk space for container images
+- Ports **5432**, **5672**, **4442-4444**, **5000** free
+
+---
+
+## Frontend unit test (no containers, offline)
+
+```bash
+MODE=dev POSTGRES_HOST=localhost POSTGRES_DEFAULT_USER=postgres \
+  POSTGRES_DEFAULT_PASSWORD=my_postgres POSTGRES_DATABASE_NAME=miminet \
+  uv run pytest front/tests/test_config_db.py -v
+```
+Expected: **7 passed**.
+
+---
+
+## Frontend E2E tests (Selenium)
+
+### 1. Start infrastructure
+
+```bash
+podman run -d --replace --rm --network host --name postgres \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=my_postgres \
+  -e POSTGRES_DB=miminet docker.io/library/postgres:18 -c fsync=off
+
+podman run -d --replace --rm --network host --name rabbitmq \
+  -e RABBITMQ_DEFAULT_USER=user -e RABBITMQ_DEFAULT_PASS=password \
+  docker.io/library/rabbitmq:3.13-management
+```
+
+Wait for postgres:
+```bash
+for i in $(seq 1 30); do
+  python3 -c "import psycopg2; psycopg2.connect(host='localhost', user='postgres', password='my_postgres', dbname='miminet')" 2>/dev/null && break
+  sleep 1
+done
+```
+
+### 2. Seed database
+
+```bash
+MODE=dev POSTGRES_HOST=localhost POSTGRES_DEFAULT_USER=postgres \
+  POSTGRES_DEFAULT_PASSWORD=my_postgres POSTGRES_DATABASE_NAME=miminet \
+  uv run python front/src/app.py dev
+```
+
+### 3. Start Flask dev server
+
+```bash
+MODE=dev POSTGRES_HOST=localhost POSTGRES_DEFAULT_USER=postgres \
+  POSTGRES_DEFAULT_PASSWORD=my_postgres POSTGRES_DATABASE_NAME=miminet \
+  nohup uv run python -c "
+import sys; sys.path.insert(0, 'front/src')
+from app import app
+app.run(host='0.0.0.0', port=5000)
+" > .tmp/flask.log 2>&1 &
+```
+
+### 4. Start Selenium hub + Chrome node
+
+```bash
+podman run -d --replace --rm --network host --name selenium-hub \
+  docker.io/selenium/hub:4.37.0
+
+podman run -d --replace --rm --network host --shm-size 2gb --name chrome \
+  -e SE_EVENT_BUS_HOST=localhost \
+  -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
+  -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
+  docker.io/selenium/node-chrome:141.0
+```
+
+### 5. Run tests
+
+```bash
+TEST_TARGET_HOST=localhost TEST_TARGET_PORT=5000 \
+  MODE=dev POSTGRES_HOST=localhost POSTGRES_DEFAULT_USER=postgres \
+  POSTGRES_DEFAULT_PASSWORD=my_postgres POSTGRES_DATABASE_NAME=miminet \
+  uv run pytest front/tests -v --timeout=300
+```
+Expected: **114 passed** in ~5:30.
+
+### 6. Cleanup
+
+```bash
+kill $(lsof -ti:5000) 2>/dev/null
+podman stop -t 0 postgres rabbitmq selenium-hub chrome
+```
+
+---
+
+## Backend tests (containerized)
+
+Build the image and run the full suite inside an isolated container:
+
+```bash
+# Build
+podman build -t miminet-back:test -f back/Dockerfile back/
+
+# Probe: verify emulation works in the container's own network namespace
+podman run --rm --entrypoint /bin/bash \
+  -v $(pwd):/repo:ro -w /repo \
+  --cap-add=ALL --device /dev/net/tun \
+  miminet-back:test \
+  -c "
+    /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
+    ovs-vswitchd >/dev/null 2>&1 &
+    mn --topo single,2 --test pingall 2>&1 | tail -5
+  "
+
+# Run the full test suite
+podman run --rm --entrypoint /bin/bash \
+  -v $(pwd):/repo:ro -w /repo \
+  --cap-add=ALL --device /dev/net/tun \
+  miminet-back:test \
+  -c "
+    /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
+    ovs-vswitchd >/dev/null 2>&1 &
+    pip3 install -q pytest
+    cd /repo/back/tests
+    PYTHONPATH=/repo/back/src pytest -v -o log_file=/tmp/back_test.log -p no:cacheprovider --basetemp=/tmp/pytest
+    mn -c >/dev/null 2>&1 || true
+  "
+```
+
+Alternatively, use the helper script (same commands, auto-detects docker/podman):
+```bash
+scripts/back-test.sh build
+scripts/back-test.sh test
+```
+
+Expected: **24 passed**.
+
+---
+
+## Required environment variables
+
+| Variable | Default | Rootless dev value |
+|----------|---------|--------------------|
+| `MODE` | `prod` | `dev` |
+| `POSTGRES_HOST` | `172.18.0.4` | `localhost` |
+| `TEST_TARGET_HOST` | `172.18.0.2` | `localhost` |
+| `TEST_TARGET_PORT` | `80` | `5000` |
+| `SELENIUM_HUB_URL` | `http://localhost:4444/wd/hub` | (unchanged) |
+
+## Notes
+
+- Ports < 1024 are unavailable under rootless podman — Flask runs on port 5000.
+- The `--network host` flag bypasses the `pasta --map-guest-addr` bug in
+  older passt versions shipped with podman 6.1.0.
+- Chrome requires `--shm-size 2gb` to avoid tab crashes under rootless podman.
+- The `front/src/app.py config.js` route uses an absolute path — no CWD dependency.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ export provider=vbox/vmware
 2. Запуск контейнеров: ```sh front/tests/docker/run.sh```
 3. Запуск тестов: ```pytest front/tests```.
 
+Запуск без Docker (rootless podman): [DEVELOPMENT.md](DEVELOPMENT.md).
+
 ### <a name="backend-test"></a> Backend
 1. Установка необходимых пакетов:
 ```bash

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
  && mkdir /opt/mininet_dependencies
 
 RUN git clone https://github.com/mimi-net/mimidump.git \
-    && cd mimidump && git checkout 32e6e5e && make prefix=/usr install && cd .. && rm -rf mimidump
+    && cd mimidump && git checkout 971ff5236 && make prefix=/usr install && cd .. && rm -rf mimidump
 
 WORKDIR /app
 ADD ./requirements.txt /app/requirements.txt

--- a/front/src/app.py
+++ b/front/src/app.py
@@ -506,8 +506,11 @@ def missing_token_callback(error):
 def confing_js():
     config = {key: os.getenv(key) for key in PUBLIC_CONFIG_KEYS if os.getenv(key)}
 
+    js_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "templates/config.js"
+    )
     js_content = render_template_string(
-        open("templates/config.js", "r", encoding="utf-8").read(), **config
+        open(js_path, "r", encoding="utf-8").read(), **config
     )
 
     return Response(js_content, mimetype="application/javascript")

--- a/front/tests/conftest.py
+++ b/front/tests/conftest.py
@@ -19,10 +19,9 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 class testing_setting:
     """Configuration settings for testing environment."""
 
-    nginx_docker_ip = "172.18.0.2"  # nginx IP inside miminet docker network
-    selenium_hub_url = (
-        "http://localhost:4444/wd/hub"  # route for sending selenium commands
-    )
+    nginx_docker_ip = os.getenv("TEST_TARGET_HOST", "172.18.0.2")
+    port = int(os.getenv("TEST_TARGET_PORT", 80))
+    selenium_hub_url = os.getenv("SELENIUM_HUB_URL", "http://localhost:4444/wd/hub")
     window_size = "1920,1080"
     auth_data = {
         "email": "selenium",
@@ -30,7 +29,15 @@ class testing_setting:
     }  # this data should be inserted into the database, selenium uses it for authentication
 
 
-MAIN_PAGE = f"http://{testing_setting.nginx_docker_ip}"
+def _main_url():
+    host = testing_setting.nginx_docker_ip
+    port = testing_setting.port
+    if port == 80:
+        return f"http://{host}"
+    return f"http://{host}:{port}"
+
+
+MAIN_PAGE = _main_url()
 HOME_PAGE = f"{MAIN_PAGE}/home"
 LOGIN_PAGE = f"{MAIN_PAGE}//auth/login.html"
 

--- a/scripts/back-test.sh
+++ b/scripts/back-test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# back-test.sh — run the Miminet backend tests locally without host root.
+#
+# Uses the back/Dockerfile image (pinned mininet + OVS + mimidump).
+# Emulation runs in the container's OWN network namespace — the host is
+# untouched. The repo is mounted READ-ONLY; containers are always --rm.
+#
+# Usage:
+#   back-test.sh build                 build the image (back/Dockerfile)
+#   back-test.sh probe                 verify emulation works in this runtime
+#   back-test.sh test                  run the full backend test suite
+#   back-test.sh collect               pytest --collect-only (expect 24)
+#   back-test.sh worker                dev Celery worker (container netns)
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/lib-back-env.sh"
+
+CMD="${1:-help}"
+
+run_emulation() {
+    local pytest_args=("$@")
+    "$BACK_ENGINE" run $(base_run_args) $(engine_flags) \
+        "$BACK_IMAGE" \
+        -c "
+            set -e
+            /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
+            ovs-vswitchd >/dev/null 2>&1 &
+            pip3 install -q pytest
+            cd /repo/back/tests
+            PYTHONPATH=/repo/back/src pytest \"${pytest_args[*]}\" -o log_file=/tmp/back_test.log -p no:cacheprovider --basetemp=/tmp/pytest || { mn -c >/dev/null 2>&1; exit 1; }
+            mn -c >/dev/null 2>&1 || true
+        "
+}
+
+cmd_build() {
+    "$BACK_ENGINE" build -t "$BACK_IMAGE" -f "$BACK_REPO_ROOT/back/Dockerfile" "$BACK_REPO_ROOT/back"
+    echo "[ok] image $BACK_IMAGE built"
+}
+
+cmd_probe() {
+    echo "[probe] running a tiny emulation in the container's own netns..."
+    host_ns=$(readlink /proc/self/ns/net)
+    "$BACK_ENGINE" run $(base_run_args) $(engine_flags) \
+        "$BACK_IMAGE" \
+        -c "
+            /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
+            ovs-vswitchd >/dev/null 2>&1 &
+            ns=\$(readlink /proc/self/ns/net)
+            echo \"host ns  : $host_ns\"
+            echo \"container: \$ns\"
+            if [ \"\$ns\" = \"$host_ns\" ]; then
+                echo \"[FAIL] container shares the HOST network namespace\"
+                exit 1
+            fi
+            echo \"[ok] container is isolated from the host netns\"
+            mn --topo single,2 --test pingall 2>&1 | tail -5
+        "
+    echo "[probe] PASS — emulation works in this runtime"
+}
+
+cmd_test() {
+    if ! "$HERE/back-test.sh" probe; then
+        echo "[fail] probe FAILED. The backend requires Mininet/OVS access"
+        echo "       only available in a privileged container. On rootless podman"
+        echo "       this is a known limitation — run in a rootful docker or CI."
+        exit 1
+    fi
+    echo "[test] running the full backend suite (24 tests)..."
+    run_emulation .
+    echo "[ok] backend tests finished"
+}
+
+cmd_collect() {
+    "$BACK_ENGINE" run $(base_run_args) \
+        "$BACK_IMAGE" \
+        -c "
+            pip3 install -q pytest
+            cd /repo/back/tests
+            PYTHONPATH=/repo/back/src pytest --collect-only -q -o log_file=/tmp/back_test.log -p no:cacheprovider
+        "
+}
+
+cmd_worker() {
+    local amqp="${BACK_AMQP_URL:-amqp://guest:guest@localhost:5672//}"
+    echo "[worker] dev Celery worker (container netns, broker: $amqp)"
+    "$BACK_ENGINE" run $(base_run_args) \
+        -e amqp_urls="$amqp" \
+        -e celery_concurrency="${celery_concurrency:-1}" \
+        -e queue_names="${queue_names:-task-checking-queue}" \
+        "$BACK_IMAGE" \
+        -c "
+            /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
+            ovs-vswitchd >/dev/null 2>&1 &
+            cd /repo/back/src
+            exec python3 -m celery -A celery_app worker --loglevel=info --concurrency=\$celery_concurrency -Q \$queue_names
+        "
+}
+
+cmd_help() {
+    cat <<'EOF'
+back-test.sh — run Miminet backend tests locally without host root.
+
+Commands:
+  build     build the back image (back/Dockerfile)
+  probe     verify emulation works in this runtime (safety gate)
+  test      run the full backend test suite
+  collect   pytest --collect-only (expect 24) — no special capabilities
+  worker    dev Celery worker (container netns; host netns untouched)
+
+Env:
+  BACK_IMAGE=...              image tag (default miminet-back:test)
+  BACK_AMQP_URL=...           broker URL for worker
+  celery_concurrency=...      worker concurrency (default 1)
+  queue_names=...             worker queues (default task-checking-queue)
+EOF
+}
+
+case "$CMD" in
+    build)   detect_engine; cmd_build ;;
+    probe)   detect_engine; cmd_probe ;;
+    test)    detect_engine; cmd_test ;;
+    collect) detect_engine; cmd_collect ;;
+    worker)  detect_engine; cmd_worker ;;
+    help|-h|--help) cmd_help ;;
+    *)
+        echo "unknown command: $CMD" >&2
+        cmd_help
+        exit 1
+        ;;
+esac

--- a/scripts/lib-back-env.sh
+++ b/scripts/lib-back-env.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# lib-back-env.sh — shared helpers for the miminet backend test harness.
+#
+# Detects the container engine (docker if reachable, else podman), defines the
+# image tag and repo root, and provides engine-aware run flags.
+
+set -euo pipefail
+
+: "${BACK_IMAGE:=miminet-back:test}"
+
+BACK_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+detect_engine() {
+    if command -v docker >/dev/null 2>&1; then
+        if docker info >/dev/null 2>&1; then
+            BACK_ENGINE="docker"
+            return 0
+        fi
+        echo "[warn] docker CLI found but daemon unreachable; trying podman" >&2
+    fi
+    if command -v podman >/dev/null 2>&1; then
+        BACK_ENGINE="podman"
+        return 0
+    fi
+    echo "ERROR: no container engine (docker or podman) available." >&2
+    exit 1
+}
+
+engine_flags() {
+    case "$BACK_ENGINE" in
+        docker) echo "--privileged" ;;
+        podman) echo "--cap-add=ALL --device /dev/net/tun" ;;
+    esac
+}
+
+base_run_args() {
+    echo "--rm --entrypoint /bin/bash -v ${BACK_REPO_ROOT}:/repo:ro -w /repo"
+}


### PR DESCRIPTION

## Summary

Four self-contained commits that enable running Miminet tests on a rootless Linux host (podman 6+) without Docker. No existing workflows are changed — all defaults remain identical.

## Commits

### 1. fix: resolve config.js path with absolute path instead of relative (`front/src/app.py`)

Opens `templates/config.js` via `os.path.abspath` instead of a bare relative path. Fixes HTTP 500 when CWD is not `/app`.

### 2. feat: parametrize test target host/port/hub via env vars (`front/tests/conftest.py`)

Adds `TEST_TARGET_HOST`, `TEST_TARGET_PORT`, and `SELENIUM_HUB_URL` env vars with current values as defaults. Rootless dev overrides: `TEST_TARGET_HOST=localhost TEST_TARGET_PORT=5000`.

### 3. chore: bump mimidump pin to 971ff5236 (`back/Dockerfile`)

Upstream PR mimi-net/mimidump#10 raised `MAX_PACKET_CAPTURE` from 100 to 1000. Bump the pinned commit, drop the temporary sed workaround.

### 4. docs: add DEVELOPMENT.md with rootless dev guide + scripts/back-test.sh

- `DEVELOPMENT.md`: step-by-step for frontend unit test (offline), frontend E2E (podman `--network host`), and containerized backend tests
- `scripts/back-test.sh` + `scripts/lib-back-env.sh`: reusable containerized backend test harness (auto-detects docker/podman, runs Mininet in its own netns)
- `README.md`: link to DEVELOPMENT.md in the testing section

## Verification

- Frontend E2E: 114/114 passed in ~5:30 (rootless podman 6.1.0, verified)
- Backend tests: 24/24 passed in container (verified)
- Unit test: 7 passed (offline, no containers)
- All 3 CI workflows expected to pass unchanged (defaults are identical)
