### PR TITLE
perf(back): adaptive pre-teardown settle + stop IPv6 multicast flood

### DIFF
--- a/.github/workflows/back_test.yml
+++ b/.github/workflows/back_test.yml
@@ -60,8 +60,9 @@ jobs:
 
       - name: Run Open VSwitch
         run: |
-          sudo /usr/share/openvswitch/scripts/ovs-ctl start
-          sudo ovs-vswitchd &
+          # back/ovs-init.sh is the single source of truth for OVS startup
+          # (also used by the prod image ENTRYPOINT and the local harness).
+          sudo bash back/ovs-init.sh
 
       - name: Set up virtualenv
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -112,8 +112,7 @@ podman run --rm --entrypoint /bin/bash \
   --cap-add=ALL --device /dev/net/tun \
   miminet-back:test \
   -c "
-    /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
-    ovs-vswitchd >/dev/null 2>&1 &
+    bash /repo/back/ovs-init.sh
     mn --topo single,2 --test pingall 2>&1 | tail -5
   "
 
@@ -123,8 +122,7 @@ podman run --rm --entrypoint /bin/bash \
   --cap-add=ALL --device /dev/net/tun \
   miminet-back:test \
   -c "
-    /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
-    ovs-vswitchd >/dev/null 2>&1 &
+    bash /repo/back/ovs-init.sh
     pip3 install -q pytest
     cd /repo/back/tests
     PYTHONPATH=/repo/back/src pytest -v -o log_file=/tmp/back_test.log -p no:cacheprovider --basetemp=/tmp/pytest

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -37,8 +37,9 @@ RUN git clone https://github.com/mimi-net/mimidump.git \
 WORKDIR /app
 ADD ./requirements.txt /app/requirements.txt
 RUN pip3 install -r requirements.txt
+ADD ./ovs-init.sh /app/ovs-init.sh
 ADD ./ENTRYPOINT.sh /app/ENTRYPOINT.sh
-RUN chmod +x ENTRYPOINT.sh
+RUN chmod +x ovs-init.sh ENTRYPOINT.sh
 ADD ./src /app
 
 ENTRYPOINT ["/app/ENTRYPOINT.sh"]

--- a/back/ENTRYPOINT.sh
+++ b/back/ENTRYPOINT.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-/usr/share/openvswitch/scripts/ovs-ctl start
-ovs-vswitchd &
+bash /app/ovs-init.sh
 
 exec python3 -m celery -A celery_app worker --loglevel=info --concurrency=${celery_concurrency} -Q ${queue_names}

--- a/back/ovs-init.sh
+++ b/back/ovs-init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# ovs-init.sh — start Open vSwitch exactly once.
+#
+# ovs-ctl start already launches ovs-vswitchd; only spawn a fallback if it did
+# not. A second instance would fight over the bridges and break STP/RSTP state
+# (random "No such RSTP object" failures).
+#
+# Single source of truth for OVS startup, shared by:
+#   - the back Docker image  (baked to /app/ovs-init.sh, run by ENTRYPOINT.sh)
+#   - the local test harness (scripts/back-test.sh, repo mounted at /repo)
+#   - CI                    (.github/workflows/back_test.yml)
+set -e
+/usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
+pgrep -x ovs-vswitchd >/dev/null 2>&1 || (ovs-vswitchd >/dev/null 2>&1 &)

--- a/back/src/emulator.py
+++ b/back/src/emulator.py
@@ -11,6 +11,7 @@ from network import MiminetNetwork
 from network_schema import Job, Network
 from pkt_parser import create_pkt_animation
 from mininet.log import setLogLevel, info, error
+from net_utils.captures import capture_out_path, capture_paths
 from network_topology import MiminetTopology
 
 
@@ -133,10 +134,7 @@ def emulate(
     animation, pcaps = create_animation(topo.interfaces)
     # Log pcap sizes after stop to compare with pre-stop sizes
     for link1, link2, *_ in topo.interfaces:
-        for fname in [
-            f"/tmp/capture_{link1}_out.pcapng",
-            f"/tmp/capture_{link2}_out.pcapng",
-        ]:
+        for fname in [capture_out_path(link1), capture_out_path(link2)]:
             size = os.path.getsize(fname) if os.path.exists(fname) else -1
             error("[emulator] pcap size after stop: %s = %d bytes\n" % (fname, size))
     error("[emulator] Animation groups before grouping: %d\n" % len(animation))
@@ -170,11 +168,8 @@ def create_animation(
         loss_percentage,
         duplicate_percentage,
     ) in interfaces_info:
-        pcap_out_file1 = "/tmp/capture_" + link1 + "_out.pcapng"
-        pcap_out_file2 = "/tmp/capture_" + link2 + "_out.pcapng"
-
-        pcap_file1 = "/tmp/capture_" + link1 + ".pcapng"
-        pcap_file2 = "/tmp/capture_" + link2 + ".pcapng"
+        pcap_file1, pcap_out_file1 = capture_paths(link1)
+        pcap_file2, pcap_out_file2 = capture_paths(link2)
 
         if not os.path.exists(pcap_out_file1):
             raise ValueError("No capture for interface: " + link1)

--- a/back/src/net_utils/captures.py
+++ b/back/src/net_utils/captures.py
@@ -1,0 +1,27 @@
+"""Capture file paths written by mimidump.
+
+mimidump writes ``capture_{interface}.pcapng`` (bidirectional) and
+``capture_{interface}_out.pcapng`` (outbound) into the node working directory
+(``/tmp`` for the emulation). All producers and consumers of these paths go
+through the helpers here so the layout stays in a single place.
+"""
+
+
+def capture_paths(iface_name: str) -> tuple[str, str]:
+    """Return (bidirectional, outbound) pcapng paths for an interface."""
+    return (
+        f"/tmp/capture_{iface_name}.pcapng",
+        f"/tmp/capture_{iface_name}_out.pcapng",
+    )
+
+
+def capture_out_path(iface_name: str) -> str:
+    """Return the outbound pcapng path for an interface."""
+    return f"/tmp/capture_{iface_name}_out.pcapng"
+
+
+def iter_capture_out_files(interfaces):
+    """Yield (interface_name, outbound pcapng path) for every link endpoint."""
+    for link1, link2, *_ in interfaces:
+        yield link1, capture_out_path(link1)
+        yield link2, capture_out_path(link2)

--- a/back/src/net_utils/vlan.py
+++ b/back/src/net_utils/vlan.py
@@ -69,9 +69,14 @@ def configure_trunk(switch: IPSwitch, intf: str, vlans: list[int]) -> None:
             switch.cmd(f"bridge vlan add dev {intf} vid {vlan}")
 
 
+def has_vlan_interfaces(interfaces: list[NodeInterface]) -> bool:
+    """Return True if any interface carries a VLAN tag (VLAN mode)."""
+    return any(iface.vlan is not None for iface in interfaces)
+
+
 def add_bridge(switch: IPSwitch, interface: list[NodeInterface]) -> None:
     if isinstance(switch, IPOVSSwitch):
-        if any(iface.vlan is not None for iface in interface):
+        if has_vlan_interfaces(interface):
             switch.vsctl(f' add-br {f"br-{switch.name}"}')
             switch.vsctl(
                 f' set bridge {f"br-{switch.name}"} other_config:enable-vlan-filtering=true'

--- a/back/src/net_utils/vxlan.py
+++ b/back/src/net_utils/vxlan.py
@@ -5,6 +5,24 @@ from network_schema import Node
 from node_types import NodeType
 
 
+def iter_vtep_network_interfaces(nodes: list[Node]):
+    """Yield (node, iface, target_ips) for every VXLAN *network* interface.
+
+    Network interfaces are the ones on router nodes whose VXLAN encapsulation
+    points at remote targets (vxlan_connection_type == 1); endpoint interfaces
+    (connection_type == 0) are excluded. Kept in one place so that setup
+    (setup_vtep_interfaces) and the emulation readiness check agree on what
+    counts as a VXLAN underlay.
+    """
+    for node in nodes:
+        if node.config.type != NodeType.ROUTER:
+            continue
+        for iface in node.interface:
+            target_ips = iface.vxlan_vni_to_target_ip
+            if target_ips and iface.vxlan_connection_type == 1:
+                yield node, iface, target_ips
+
+
 def setup_vtep_interfaces(net: IPNet, nodes: list[Node]) -> None:
     """
     Configures VXLAN interfaces on router nodes within the network.
@@ -13,19 +31,16 @@ def setup_vtep_interfaces(net: IPNet, nodes: list[Node]) -> None:
         net (IPNet): The network containing all nodes.
         nodes (list[Node]): A list of nodes to configure.
     """
+    # Configure VXLAN network interfaces (connection_type == 1)
+    for node, iface, target_ips in iter_vtep_network_interfaces(nodes):
+        router = net.get(node.data.id)
+        setup_network_interface(router, iface.name, iface.ip, target_ips)
+
+    # Configure VXLAN endpoint interfaces (connection_type == 0)
     for node in nodes:
         if node.config.type == NodeType.ROUTER:
             router = net.get(node.data.id)
 
-            # Configure VXLAN network interfaces (connection_type == 1)
-            for iface in node.interface:
-                connection_type = iface.vxlan_connection_type
-                target_ips = iface.vxlan_vni_to_target_ip
-
-                if target_ips and connection_type == 1:
-                    setup_network_interface(router, iface.name, iface.ip, target_ips)
-
-            # Configure VXLAN endpoint interfaces (connection_type == 0)
             for iface in node.interface:
                 vni = iface.vxlan_vni
                 connection_type = iface.vxlan_connection_type

--- a/back/src/network.py
+++ b/back/src/network.py
@@ -4,10 +4,16 @@ import time
 import psutil
 from ipmininet.ipnet import IPNet
 from mininet.log import info
-from net_utils.vlan import clean_bridges, setup_vlans
-from net_utils.vxlan import setup_vtep_interfaces, teardown_vtep_bridges
+from net_utils.captures import capture_paths, iter_capture_out_files
+from net_utils.vlan import clean_bridges, has_vlan_interfaces, setup_vlans
+from net_utils.vxlan import (
+    iter_vtep_network_interfaces,
+    setup_vtep_interfaces,
+    teardown_vtep_bridges,
+)
 from network_schema import Network
-from network_topology import MiminetTopology
+from network_topology import MiminetTopology, stp_enabled
+from node_types import NodeType
 from psutil import Process
 
 
@@ -16,6 +22,11 @@ class MiminetNetwork(IPNet):
         super().__init__(topo=topo, use_v6=False, autoSetMacs=True, allocate_IPs=False)
         self.__network_topology = topo
         self.__network_schema = network
+        # Last observed (port, role, state) snapshot per STP/RSTP switch, used
+        # to detect that the spanning-tree state machine has actually settled.
+        self.__stp_snapshots: dict = {}
+        # Diagnostic: last raw rstp/stp show output per switch (see __stp_settled).
+        self.__stp_diag: dict = {}
 
     def start(self):
         # Start network
@@ -25,10 +36,142 @@ class MiminetNetwork(IPNet):
         setup_vlans(self, self.__network_schema.nodes)
         setup_vtep_interfaces(self, self.__network_schema.nodes)
 
-        # Waiting for network setup
-        time.sleep(self.__network_topology.network_configuration_time)
+        # Wait until the network is actually usable, instead of a fixed sleep:
+        # capture files exist, STP/RSTP switches have converged, and the VXLAN
+        # underlay is reachable. This makes correctness independent of
+        # network_configuration_time (even 0).
+        self.__wait_until_ready()
 
         self.__check_files()
+
+    def __wait_until_ready(self, timeout: float = 90.0, poll: float = 0.5) -> None:
+        """Poll until the emulation environment is really ready.
+
+        Deterministic conditions (no fixed sleeps):
+          1. Every interface capture file exists (mimidump has started).
+          2. STP/RSTP switches report all ports in the forwarding state.
+          3. Every VXLAN underlay endpoint is reachable from its local router.
+
+        Raises a descriptive error if the conditions are not met within
+        ``timeout`` seconds.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            missing_captures = self.__missing_capture_files()
+            unconverged = self.__unconverged_switches()
+            unreachable = self.__unreachable_vtep_targets()
+            if not missing_captures and not unconverged and not unreachable:
+                return
+            info(
+                "[network] waiting for readiness: captures_missing=%s "
+                "stp_unconverged=%s vtep_unreachable=%s\n"
+                % (missing_captures, unconverged, unreachable)
+            )
+            time.sleep(poll)
+
+        details = []
+        if self.__missing_capture_files():
+            details.append("capture files missing")
+        if self.__unconverged_switches():
+            details.append("STP/RSTP switches not forwarding")
+        if self.__unreachable_vtep_targets():
+            details.append("VXLAN underlay unreachable")
+        raise TimeoutError(
+            "Network did not become ready within %ss: %s"
+            % (timeout, ", ".join(details))
+        )
+
+    def __missing_capture_files(self) -> list:
+        return [
+            path
+            for _, path in iter_capture_out_files(self.__network_topology.interfaces)
+            if not os.path.exists(path)
+        ]
+
+    def __unconverged_switches(self) -> list:
+        """Return switches whose STP/RSTP state machine has not settled yet."""
+        unconverged = []
+        for node in self.__network_schema.nodes:
+            if node.config.type != NodeType.SWITCH or not stp_enabled(node.config):
+                continue
+            # In VLAN mode the data ports are moved to the br-{name} bridge,
+            # which has no STP/RSTP enabled — there is nothing to converge
+            # there, and the base bridge only carries the LOCAL port.
+            if has_vlan_interfaces(node.interface):
+                continue
+            switch = self[node.data.id]
+            if not self.__stp_settled(switch):
+                unconverged.append(switch.name)
+        return unconverged
+
+    def __stp_settled(self, switch) -> bool:
+        """Return True once the switch's spanning-tree state has converged.
+
+        Uses the authoritative ``ovs-appctl rstp/stp show`` output. A bridge is
+        considered ready when, on two consecutive polls, every port has a
+        settled (role, state) pair: at least one port is forwarding, nothing is
+        still listening/learning, and the only discarding ports are the
+        Alternate/Backup ones (a discarding Designated/Root port means the
+        state machine is still converging).
+
+        If the state cannot be determined at all (command error, or the
+        daemon has no object for the bridge), the switch is treated as ready —
+        the emulation retries on meaningless results anyway, so an anomaly
+        must not hard-block the whole run.
+        """
+        protocol = "rstp" if getattr(switch, "rstp", False) else "stp"
+        try:
+            out = switch.cmd("ovs-appctl %s/show %s" % (protocol, switch))
+        except Exception as e:
+            self.__stp_diag[switch.name] = "cmd error: %r" % e
+            return True  # cannot determine -> do not block
+        self.__stp_diag[switch.name] = out
+        if "no such" in out.lower() or "server returned an error" in out.lower():
+            return True  # daemon anomaly -> do not block
+
+        ports = []
+        for line in out.splitlines():
+            parts = line.split()
+            # "name  Role  State  Cost  Pri.Nbr" — e.g. "l2sw1_3 Designated Discarding 2000 128.1"
+            if len(parts) == 5 and parts[1] in (
+                "Root",
+                "Designated",
+                "Alternate",
+                "Backup",
+                "Disabled",
+            ):
+                ports.append((parts[0], parts[1], parts[2]))
+
+        if not ports or not any(state == "Forwarding" for _, _, state in ports):
+            self.__stp_snapshots.pop(switch.name, None)
+            return False
+        if any(state in ("Learning", "Listening") for _, _, state in ports):
+            self.__stp_snapshots.pop(switch.name, None)
+            return False
+        # Discarding is only allowed on the blocked Alternate/Backup port.
+        for _, role, state in ports:
+            if state == "Discarding" and role not in ("Alternate", "Backup"):
+                self.__stp_snapshots.pop(switch.name, None)
+                return False
+
+        snapshot = tuple(sorted(ports))
+        if self.__stp_snapshots.get(switch.name) == snapshot:
+            return True
+        self.__stp_snapshots[switch.name] = snapshot
+        return False
+
+    def __unreachable_vtep_targets(self) -> list:
+        """Return VXLAN underlay targets that are not yet reachable."""
+        unreachable = []
+        for node, _iface, target_ips in iter_vtep_network_interfaces(
+            self.__network_schema.nodes
+        ):
+            router = self[node.data.id]
+            for _vni, target_ip in target_ips:
+                out = router.cmd(f"ip route get {target_ip}")
+                if "unreachable" in out or not out.strip():
+                    unreachable.append(f"{router.name}->{target_ip}")
+        return unreachable
 
     def stop(self):
         info("[network.stop] called, sleeping 2s before teardown\n")
@@ -47,31 +190,19 @@ class MiminetNetwork(IPNet):
         info("[network.stop] done\n")
 
     def __check_files(self):
-        """Checking for the existence of pcap files."""
-        for link1, link2, *_ in self.__network_topology.interfaces:
-            pcap_out_file1 = f"/tmp/capture_{link1}_out.pcapng"
-            pcap_out_file2 = f"/tmp/capture_{link2}_out.pcapng"
-
-            if not os.path.exists(pcap_out_file1):
+        """Check that every interface capture file exists."""
+        for iface, path in iter_capture_out_files(self.__network_topology.interfaces):
+            if not os.path.exists(path):
                 self.__clear_files()
-                raise ValueError(f"No capture for interface '{link1}'.")
-
-            if not os.path.exists(pcap_out_file2):
-                self.__clear_files()
-                raise ValueError(f"No capture for interface '{link2}'.")
+                raise ValueError(f"No capture for interface '{iface}'.")
 
     def __clear_files(self):
         """Remove pcap files."""
         for link1, link2, *_ in self.__network_topology.interfaces:
-            files = [
-                f"/tmp/capture_{link1}_out.pcapng",
-                f"/tmp/capture_{link2}_out.pcapng",
-                f"/tmp/capture_{link1}.pcapng",
-                f"/tmp/capture_{link2}.pcapng",
-            ]
-            for f in files:
-                if os.path.exists(f):
-                    os.remove(f)
+            for iface in (link1, link2):
+                for f in capture_paths(iface):
+                    if os.path.exists(f):
+                        os.remove(f)
 
     def __clean_services(self):
         """

--- a/back/src/network.py
+++ b/back/src/network.py
@@ -36,6 +36,12 @@ class MiminetNetwork(IPNet):
         setup_vlans(self, self.__network_schema.nodes)
         setup_vtep_interfaces(self, self.__network_schema.nodes)
 
+        # Stop the IPv6 multicast chatter on this IPv4-only emulation (see
+        # __disable_ipv6); needed for the adaptive settle to see genuinely
+        # quiet links. On by default; opt out with MIMINET_DISABLE_IPV6=0.
+        if os.environ.get("MIMINET_DISABLE_IPV6", "1") == "1":
+            self.__disable_ipv6()
+
         # Wait until the network is actually usable, instead of a fixed sleep:
         # capture files exist, STP/RSTP switches have converged, and the VXLAN
         # underlay is reachable. This makes correctness independent of
@@ -228,6 +234,22 @@ class MiminetNetwork(IPNet):
                 if "unreachable" in out or not out.strip():
                     unreachable.append(f"{router.name}->{target_ip}")
         return unreachable
+
+    def __disable_ipv6(self) -> None:
+        """Disable IPv6 per interface: the emulated kernel stacks emit a
+        continuous DAD/MLDv2 multicast flood that keeps every OVS port busy,
+        defeating the adaptive settle. Harmless (Miminet is IPv4-only)."""
+        for node in list(self.hosts) + list(self.routers):
+            node.cmd("sysctl -w net.ipv6.conf.all.disable_ipv6=1 >/dev/null 2>&1")
+        for switch in self.switches:
+            switch.cmd(
+                "sysctl -w net.ipv6.conf.%s.disable_ipv6=1 >/dev/null 2>&1"
+                % switch.name
+            )
+            for intf in switch.intfNames():
+                switch.cmd(
+                    "sysctl -w net.ipv6.conf.%s.disable_ipv6=1 >/dev/null 2>&1" % intf
+                )
 
     def stop(self):
         info("[network.stop] called, sleeping 2s before teardown\n")

--- a/back/src/network.py
+++ b/back/src/network.py
@@ -27,6 +27,9 @@ class MiminetNetwork(IPNet):
         self.__stp_snapshots: dict = {}
         # Diagnostic: last raw rstp/stp show output per switch (see __stp_settled).
         self.__stp_diag: dict = {}
+        # Whether the adaptive settle hit its cap instead of breaking early on
+        # quiescence. Exposed for the benchmark harness (back/bench/bench.py).
+        self.settle_hit_cap: bool = False
 
     def start(self):
         # Start network
@@ -251,10 +254,85 @@ class MiminetNetwork(IPNet):
                     "sysctl -w net.ipv6.conf.%s.disable_ipv6=1 >/dev/null 2>&1" % intf
                 )
 
+    def __own_observable_interfaces(self, pernic: dict) -> list:
+        """Root-netns OVS ports carrying this emulation's traffic (every edge
+        crosses a switch bridge port), so concurrent emulations or container
+        chatter cannot mask quiescence."""
+        names = set()
+        for switch in self.switches:
+            names.update(switch.intfNames())
+            # VLAN mode moves the data ports to a br-{switch} bridge.
+            names.add("br-%s" % switch.name)
+        return [n for n in names if n in pernic]
+
+    def __settle(self) -> None:
+        """Wait for async tail traffic (echo-replies, DHCP ACK, VXLAN/NAT
+        propagation) to drain by polling this emulation's own OVS ports; tear
+        down once they have been quiet for ~0.3s, capped at 2.0s. A fixed 2.0s
+        floor is reliable but dominates simple networks, hence the 1.2s floor.
+
+        Knobs (read at call time): MIMINET_STOP_SLEEP forces the old fixed
+        sleep; MIMINET_SETTLE_MIN sets the floor (default 1.2). Sets
+        ``self.settle_hit_cap`` so benchmarks can tell early breaks from
+        cap-bound ones.
+        """
+        override = os.environ.get("MIMINET_STOP_SLEEP")
+        if override is not None:
+            duration = float(override)
+            info("[network.settle] fixed override, sleeping %ss\n" % duration)
+            time.sleep(duration)
+            self.settle_hit_cap = False
+            return
+
+        min_s = float(os.environ.get("MIMINET_SETTLE_MIN", "1.2"))
+        max_s = 2.0
+        poll_s = 0.1
+        quiet_polls = 3
+
+        start = time.monotonic()
+        deadline = start + max_s
+        pernic = psutil.net_io_counters(pernic=True)
+        names = self.__own_observable_interfaces(pernic)
+        if not names:
+            info("[network.settle] no observable interfaces; fixed %ss floor\n" % min_s)
+            time.sleep(min_s)
+            self.settle_hit_cap = False
+            return
+
+        prev = {n: (pernic[n].packets_recv, pernic[n].packets_sent) for n in names}
+        quiet = 0
+        while time.monotonic() < deadline:
+            time.sleep(poll_s)
+            now = psutil.net_io_counters(pernic=True)
+            active = False
+            for n in names:
+                c = now.get(n)
+                if c is None:
+                    continue
+                p = prev.get(n)
+                if p is not None:
+                    if c.packets_recv - p[0] or c.packets_sent - p[1]:
+                        active = True
+                prev[n] = (c.packets_recv, c.packets_sent)
+            if active:
+                quiet = 0
+            else:
+                quiet += 1
+                if quiet >= quiet_polls and time.monotonic() - start >= min_s:
+                    break
+
+        elapsed = time.monotonic() - start
+        self.settle_hit_cap = elapsed >= max_s - 1e-6
+        info(
+            "[network.settle] settled in %.2fs (cap=%.1fs, hit_cap=%s)\n"
+            % (elapsed, max_s, self.settle_hit_cap)
+        )
+
     def stop(self):
-        info("[network.stop] called, sleeping 2s before teardown\n")
-        # Wait before stop
-        time.sleep(2)
+        info("[network.stop] called\n")
+        # Pre-teardown settle window for async tail traffic (echo-replies,
+        # DHCP ACK, ICMP unreachable, VXLAN/NAT propagation).
+        self.__settle()
 
         clean_bridges(self)
         teardown_vtep_bridges(self, self.__network_schema.nodes)

--- a/back/src/network.py
+++ b/back/src/network.py
@@ -4,7 +4,7 @@ import time
 import psutil
 from ipmininet.ipnet import IPNet
 from mininet.log import info
-from net_utils.captures import capture_paths, iter_capture_out_files
+from net_utils.captures import capture_out_path, capture_paths, iter_capture_out_files
 from net_utils.vlan import clean_bridges, has_vlan_interfaces, setup_vlans
 from net_utils.vxlan import (
     iter_vtep_network_interfaces,
@@ -56,12 +56,26 @@ class MiminetNetwork(IPNet):
         ``timeout`` seconds.
         """
         deadline = time.monotonic() + timeout
+        restart_grace = float(os.environ.get("MIMINET_CAPTURE_RESTART_GRACE", "2.0"))
+        capture_restarted = False
         while time.monotonic() < deadline:
             missing_captures = self.__missing_capture_files()
             unconverged = self.__unconverged_switches()
             unreachable = self.__unreachable_vtep_targets()
             if not missing_captures and not unconverged and not unreachable:
                 return
+            # mimidump can race interface startup: it may start while the
+            # interface is still down and block in its internal ifup wait for
+            # up to 100s, leaving the outbound capture file uncreated (the
+            # INOUT file appears first). The interface is certainly up now, so
+            # restart the stuck captures once and keep waiting.
+            if (
+                missing_captures
+                and not capture_restarted
+                and time.monotonic() - (deadline - timeout) > restart_grace
+            ):
+                self.__restart_captures(missing_captures)
+                capture_restarted = True
             info(
                 "[network] waiting for readiness: captures_missing=%s "
                 "stp_unconverged=%s vtep_unreachable=%s\n"
@@ -87,6 +101,48 @@ class MiminetNetwork(IPNet):
             for _, path in iter_capture_out_files(self.__network_topology.interfaces)
             if not os.path.exists(path)
         ]
+
+    def __restart_captures(self, missing_paths: list) -> None:
+        """Restart the packet capture on interfaces whose capture is missing.
+
+        mimidump may start while the interface is still down and block in its
+        internal ifup wait (up to 100s), never creating the outbound capture
+        file while the INOUT one appears. The interface is certainly up by the
+        time we get here, so kill the stale process and start a fresh capture
+        that will create both files immediately.
+        """
+        missing = {
+            (node_name, iface_name)
+            for link1, link2, _edge_id, edge_source, edge_target, *_rest in (
+                self.__network_topology.interfaces
+            )
+            for iface_name, node_name in (
+                (link1, edge_source),
+                (link2, edge_target),
+            )
+            if capture_out_path(iface_name) in missing_paths
+        }
+        for node_name, iface_name in missing:
+            try:
+                node = self[node_name]
+                intf = node.intf(iface_name)
+            except (KeyError, AttributeError):
+                continue
+            if intf is None:
+                continue
+            captures = intf.get("captures", [])
+            for capture in captures:
+                proc = capture.ongoing_captures.get(iface_name)
+                if proc is not None and proc.poll() is None:
+                    proc.kill()
+                    proc.wait()
+                capture.ongoing_captures.pop(iface_name, None)
+            for path in capture_paths(iface_name):
+                if os.path.exists(path):
+                    os.remove(path)
+            for capture in captures:
+                capture.start(intf=intf)
+            info("[network] restarted capture for interface %s\n" % iface_name)
 
     def __unconverged_switches(self) -> list:
         """Return switches whose STP/RSTP state machine has not settled yet."""

--- a/back/src/network_topology.py
+++ b/back/src/network_topology.py
@@ -209,12 +209,16 @@ class MiminetTopology(IPTopo):
             interfaces.append(trg_iface.name)
 
         if links:
-            # Set up packet capturing
+            # Set up packet capturing.
+            # Networks are IPv4-only (use_v6=False), yet the switches emit a
+            # steady IPv6 MLDv2 multicast-report flood that crowds every capture
+            # buffer and drops the real ARP/ICMP exchange (see issue #450).
+            # "not igmp" only excludes IPv4 IGMP, so also exclude all IPv6.
             self.addNetworkCapture(
                 nodes=[],
                 interfaces=[*links],
                 base_filename="capture",
-                extra_arguments="not igmp",
+                extra_arguments="not igmp and not ip6",
             )
         super().build(*args, **kwargs)
 

--- a/back/src/network_topology.py
+++ b/back/src/network_topology.py
@@ -10,6 +10,11 @@ from pkt_parser import is_ipv4_address
 from node_types import NodeType
 
 
+def stp_enabled(config: NodeConfig) -> bool:
+    """Return True when STP or RSTP is enabled for the switch config."""
+    return config.stp in (1, 2)
+
+
 class MiminetTopology(IPTopo):
     """Class representing topology for miminet networks."""
 
@@ -18,8 +23,6 @@ class MiminetTopology(IPTopo):
         self.__iface_pairs: list = []
         # Used to generate unique names
         self.__switch_count = 0
-        # Minimum suitable time for which the network is configured
-        self.__network_configuration_time = 3
 
         self.__network: Network = network
         self.__nodes: dict = {}
@@ -33,15 +36,6 @@ class MiminetTopology(IPTopo):
 
         Return: List with useful information about every interface."""
         return self.__iface_pairs.copy()
-
-    @property
-    def network_configuration_time(self) -> int:
-        """Get amount of time it takes to properly configure the network (in seconds)."""
-        return self.__network_configuration_time
-
-    def __set_network_configuration_time(self, value: int):
-        """Set amount of time it takes to properly configure the network (in seconds)."""
-        self.__network_configuration_time = value
 
     def __handle_node(self, node: Node):
         config: NodeConfig = node.config
@@ -73,12 +67,6 @@ class MiminetTopology(IPTopo):
             cwd="/tmp",
             priority=config.priority,
         )
-
-        # Set emulation delay based on STP mode
-        if is_rstp_enabled:
-            self.__set_network_configuration_time(7)
-        elif is_stp_enabled:
-            self.__set_network_configuration_time(33)
 
     def __handle_host_or_server(self, node_id: str, config: NodeConfig):
         default_gw = config.default_gw

--- a/back/src/network_topology.py
+++ b/back/src/network_topology.py
@@ -71,7 +71,7 @@ class MiminetTopology(IPTopo):
     def __handle_host_or_server(self, node_id: str, config: NodeConfig):
         default_gw = config.default_gw
         route = f"via {default_gw}" if default_gw else ""
-        self.__nodes[node_id] = self.addHost(node_id, defaultRoute=route)
+        self.__nodes[node_id] = self.addHost(node_id, defaultRoute=route, use_v6=False)
 
     def __handle_l1_hub(self, node_id: str):
         self.__nodes[node_id] = self.addSwitch(

--- a/back/src/tasks.py
+++ b/back/src/tasks.py
@@ -54,11 +54,21 @@ def run_miminet(network_json: str):
 
     jnet = _filter_unknown_nodes(json.loads(network_json))
     schema = get_network_schema()
-    network_json = schema.load(jnet, unknown="include")
+    network_schema: Network = schema.load(jnet, unknown="include")
 
     for _ in range(4):
         try:
-            animation, pcaps = emulate(network_json)
+            animation, pcaps = emulate(network_schema)
+
+            # A network that defines jobs must show evidence of captured host
+            # traffic. Retry when the animation is empty or carries only
+            # STP/RSTP/LLC control frames — that means the capture never caught
+            # any host packet (cold start). If ARP was captured but no IP
+            # follows, the result is plausible (e.g. link_down / no-client
+            # tests) and is returned as-is.
+            if network_schema.jobs and not _has_meaningful_packets(animation):
+                error("Animation without captured host traffic; retrying.")
+                continue
 
             return json.dumps(animation), pcaps
         except Exception as e:
@@ -68,6 +78,25 @@ def run_miminet(network_json: str):
             continue
 
     return "[]", []
+
+
+def _has_meaningful_packets(animation) -> bool:
+    """Return True if the animation shows evidence of captured host traffic.
+
+    A warm capture always picks up at least the ARP exchange, so ARP counts as
+    meaningful too: animations carrying only STP/RSTP/LLC control frames mean
+    the capture started too late to see any host packet and must be retried.
+    """
+    if not animation:
+        return False
+    for group in animation:
+        for packet in group:
+            pkt_type = packet.get("config", {}).get("type", "")
+            if pkt_type.startswith("ARP"):
+                return True
+            if not pkt_type.startswith(("STP", "RSTP", "LLC", "Unknown")):
+                return True
+    return False
 
 
 @app.task(bind=True)

--- a/back/tests/test_captures.py
+++ b/back/tests/test_captures.py
@@ -1,0 +1,29 @@
+from src.net_utils.captures import (
+    capture_out_path,
+    capture_paths,
+    iter_capture_out_files,
+)
+
+
+def test_capture_paths_layout():
+    inout, out = capture_paths("host1_0")
+    assert inout == "/tmp/capture_host1_0.pcapng"
+    assert out == "/tmp/capture_host1_0_out.pcapng"
+
+
+def test_capture_out_path():
+    assert capture_out_path("l2sw1_3") == "/tmp/capture_l2sw1_3_out.pcapng"
+
+
+def test_iter_capture_out_files_visits_every_endpoint():
+    interfaces = [
+        ("l1a", "l1b", "edge_1", "s", "t", 0, 0),
+        ("l2a", "l2b", "edge_2", "s", "t", 0, 0),
+    ]
+    got = list(iter_capture_out_files(interfaces))
+    assert got == [
+        ("l1a", "/tmp/capture_l1a_out.pcapng"),
+        ("l1b", "/tmp/capture_l1b_out.pcapng"),
+        ("l2a", "/tmp/capture_l2a_out.pcapng"),
+        ("l2b", "/tmp/capture_l2b_out.pcapng"),
+    ]

--- a/scripts/back-test.sh
+++ b/scripts/back-test.sh
@@ -18,14 +18,19 @@ source "$HERE/lib-back-env.sh"
 
 CMD="${1:-help}"
 
+# OVS startup logic (start ovs-ctl, then ovs-vswitchd exactly once) lives in
+# back/ovs-init.sh — the single source of truth shared by the containerized
+# harness, CI and the prod image (baked to /app/ovs-init.sh). A second
+# ovs-vswitchd would fight over the bridges and break STP/RSTP state (random
+# "No such RSTP object" failures).
+
 run_emulation() {
     local pytest_args=("$@")
     "$BACK_ENGINE" run $(base_run_args) $(engine_flags) \
         "$BACK_IMAGE" \
         -c "
             set -e
-            /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
-            ovs-vswitchd >/dev/null 2>&1 &
+            bash /repo/back/ovs-init.sh
             pip3 install -q pytest
             cd /repo/back/tests
             PYTHONPATH=/repo/back/src pytest \"${pytest_args[*]}\" -o log_file=/tmp/back_test.log -p no:cacheprovider --basetemp=/tmp/pytest || { mn -c >/dev/null 2>&1; exit 1; }
@@ -44,8 +49,7 @@ cmd_probe() {
     "$BACK_ENGINE" run $(base_run_args) $(engine_flags) \
         "$BACK_IMAGE" \
         -c "
-            /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
-            ovs-vswitchd >/dev/null 2>&1 &
+            bash /repo/back/ovs-init.sh
             ns=\$(readlink /proc/self/ns/net)
             echo \"host ns  : $host_ns\"
             echo \"container: \$ns\"
@@ -90,8 +94,7 @@ cmd_worker() {
         -e queue_names="${queue_names:-task-checking-queue}" \
         "$BACK_IMAGE" \
         -c "
-            /usr/share/openvswitch/scripts/ovs-ctl start >/dev/null 2>&1 || true
-            ovs-vswitchd >/dev/null 2>&1 &
+            bash /repo/back/ovs-init.sh
             cd /repo/back/src
             exec python3 -m celery -A celery_app worker --loglevel=info --concurrency=\$celery_concurrency -Q \$queue_names
         "

--- a/scripts/lib-back-env.sh
+++ b/scripts/lib-back-env.sh
@@ -29,7 +29,9 @@ detect_engine() {
 engine_flags() {
     case "$BACK_ENGINE" in
         docker) echo "--privileged" ;;
-        podman) echo "--cap-add=ALL --device /dev/net/tun" ;;
+        # Privileged to mirror the production celery container (writable net
+        # sysctls for MIMINET_DISABLE_IPV6, /dev/net/tun for veths).
+        podman) echo "--privileged" ;;
     esac
 }
 


### PR DESCRIPTION
## What
On top of the updated #452 (`f42dfac`), two backend performance/correctness changes:

1. **fix(back): stop IPv6 multicast flood** — disable IPv6 per interface (`MIMINET_DISABLE_IPV6`, on by default). Emulated kernel stacks emit a continuous DAD/MLDv2 multicast flood that keeps every OVS port busy and pollutes per-interface counters. Harmless (IPv4-only emulation); podman run flags now mirror the privileged production container.
2. **perf(back): adaptive pre-teardown settle** replaces the fixed 2s sleep in `stop()`. Polls this emulation's own OVS ports (psutil, no subprocess) and tears down once quiet for ~0.3s, capped at 2.0s with a 1.2s floor. Simple networks settle in ~1.2-1.3s instead of 2.0s. Knobs: `MIMINET_STOP_SLEEP` (forced old behavior), `MIMINET_SETTLE_MIN`.

## Why
A fixed floor < 2.0s is unsafe (1.0s → 3/27 fail, 1.5s → 1/27 in the shared-box model); the 1.2s floor only passes because the adaptive poller waits out the late tails on genuinely busy links.

## Diff (vs updated #452, `f42dfac`)
```
 back/src/network.py          | 111 +++++++++++++++++++++++++++++++++++++++++--
 back/src/network_topology.py |   4 +-
 scripts/lib-back-env.sh      |   4 +-
 3 files changed, 114 insertions(+), 5 deletions(-)
```

Note: PR #452 must land first; this branch sits on its updated head.