### PR TITLE
ci(dependabot): per-directory pip groups, docker coverage, monthly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,38 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/back"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      pip-dependencies:
+      back-pip-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/front"
+    schedule:
+      interval: "monthly"
+    groups:
+      front-pip-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/back"
+    schedule:
+      interval: "monthly"
+    groups:
+      back-docker-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/front"
+    schedule:
+      interval: "monthly"
+    groups:
+      front-docker-images:
         patterns:
           - "*"
 
@@ -17,4 +44,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-


### PR DESCRIPTION
## What
Restructure Dependabot configuration to be explicit and per-directory:

- **pip**: separate entries for `/back` and `/front` (each with its own grouped PR), replacing the single root-level `/` entry that did not cover the nested requirements files
- **docker**: add coverage for the `back` and `front` images (base-image updates now visible as dependabot PRs)
- **cadence**: everything monthly, grouped into one PR per category per directory

## Diff
```
 .github/dependabot.yml | 34 ++++++++++++++++++++++++++++++----
 1 file changed, 30 insertions(+), 4 deletions(-)
```

## Value
- Fewer, reviewable dependency PRs (monthly groups instead of weekly singles)
- Nested `back`/`front` requirements files now actually covered
- Docker base-image updates (e.g. `ubuntu:` / `python:`) surface via dependabot
- GitHub Actions still grouped monthly

No code or CI behavior changes — config only. CI validates the file parses (no workflow edits).