### PR TITLE
fix(back): protocol-aware retry + dnsmasq bind wait for DHCP jobs (fixes #464)

### DIFF
--- a/back/src/jobs.py
+++ b/back/src/jobs.py
@@ -532,7 +532,29 @@ def dhcp_server(job: Job, job_host):
         info(f"[dhcp_server] could not read dnsmasq config: {e}")
 
     job_host.start_daemon(daemon)
+    _wait_for_daemon_bind(job_host, daemon, timeout=15)
     info(f"[dhcp_server] dnsmasq started on host={job_host.name}")
+
+
+def _wait_for_daemon_bind(host, daemon: Dnsmasq, timeout: float = 15.0) -> None:
+    """Wait until a daemon has bound its sockets.
+
+    A DHCP client may start right after the server job and race dnsmasq's
+    startup, so the server job must not return until the daemon is actually
+    listening. Uses the daemon's own liveness probe (socket table) instead of a
+    fixed sleep.
+
+    Args:
+        host: Host the daemon was started on.
+        daemon (Dnsmasq): Daemon to wait for.
+        timeout (float): Maximum time in seconds to wait.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if daemon.pids:
+            return
+        time.sleep(0.1)
+    info(f"[dhcp_server] dnsmasq did not bind sockets within {timeout}s on {host.name}")
 
 
 class Jobs:

--- a/back/src/tasks.py
+++ b/back/src/tasks.py
@@ -86,16 +86,34 @@ def _has_meaningful_packets(animation) -> bool:
     A warm capture always picks up at least the ARP exchange, so ARP counts as
     meaningful too: animations carrying only STP/RSTP/LLC control frames mean
     the capture started too late to see any host packet and must be retried.
+
+    DHCP is protocol-aware: a client's Discover alone (without a server Offer,
+    Request or ACK) means the DHCP server was not ready when the client ran, so
+    the capture is not meaningful and must be retried.
     """
     if not animation:
         return False
+
+    dhcp_seen = False
+    dhcp_answered = False
+
     for group in animation:
         for packet in group:
             pkt_type = packet.get("config", {}).get("type", "")
+
+            if pkt_type.startswith("DHCP"):
+                dhcp_seen = True
+                if not pkt_type.startswith("DHCP Discover"):
+                    dhcp_answered = True
+                continue
+
             if pkt_type.startswith("ARP"):
                 return True
             if not pkt_type.startswith(("STP", "RSTP", "LLC", "Unknown")):
                 return True
+
+    if dhcp_seen:
+        return dhcp_answered
     return False
 
 

--- a/front/tests/conftest.py
+++ b/front/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from contextlib import contextmanager
 from typing import Generator
 from unittest.mock import MagicMock
@@ -7,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from requests import Session
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -52,30 +53,66 @@ class MiminetTester(WebDriver):
         """
         Waits for the specified element to become clickable before clicking it.
 
+        Re-finds the element on every attempt so a stale element caused by a
+        page re-render is not treated as a failure.
+
         Args:
             by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             timeout (int): The maximum time in seconds to wait (default: 20).
         """
-        WebDriverWait(self, timeout).until(
-            EC.element_to_be_clickable((by, element))
-        ).click()
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutException(
+                    f"Element {element} is not clickable within {timeout} seconds."
+                )
+            try:
+                WebDriverWait(self, remaining).until(
+                    EC.element_to_be_clickable((by, element))
+                ).click()
+                return
+            except StaleElementReferenceException:
+                continue
 
-    def drag_and_drop(self, source: WebElement, target: WebElement, x: int, y: int):
+    def drag_and_drop(self, source, target, x: int, y: int):
         """Performs a drag-and-drop action from a source element to a target element.
 
+        Elements may be given either as WebElement instances or as (by, selector)
+        locator tuples; locators are re-resolved on each attempt so a stale
+        element during the action is not treated as a failure.
+
         Args:
-            source (WebElement): The source element to be dragged.
-            target (WebElement): The target element to drop the source element onto.
+            source (WebElement | tuple): The source element to be dragged.
+            target (WebElement | tuple): The target element to drop the source element onto.
             x (int): The x-offset to move to.
             y (int): The y-offset to move to.
         """
-        actions_chain = ActionChains(self)
+        deadline = time.monotonic() + 20
 
-        actions_chain.click_and_hold(source)
-        actions_chain.move_to_element_with_offset(target, x, y)
-        actions_chain.release()
-        actions_chain.perform()
+        def _resolve(element):
+            if isinstance(element, tuple):
+                by, selector = element
+                return self.find_element(by, selector)
+            return element
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutException(
+                    "Drag-and-drop did not complete within 20 seconds."
+                )
+            try:
+                actions_chain = ActionChains(self)
+
+                actions_chain.click_and_hold(_resolve(source))
+                actions_chain.move_to_element_with_offset(_resolve(target), x, y)
+                actions_chain.release()
+                actions_chain.perform()
+                return
+            except StaleElementReferenceException:
+                continue
 
     def exist_element(self, by: str, element: str):
         """
@@ -119,13 +156,37 @@ class MiminetTester(WebDriver):
         Waits until text appears in the element.
 
         Args:
-            by (str): The locator strategy (e.g., By.ID, By.XPATH).
+            by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             timeout (int): The maximum time in seconds to wait (default: 20).
         """
         WebDriverWait(self, timeout).until(
             EC.text_to_be_present_in_element((by, element), text)
         )
+
+    def wait_until_value(self, by: str, element: str, value: str, timeout=20):
+        """
+        Waits until an input field holds the given value.
+
+        Re-finds the element on each attempt so a stale element caused by a page
+        re-render is not treated as a failure.
+
+        Args:
+            by (By): The locator strategy (e.g., By.ID, By.XPATH).
+            element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
+            value (str): The value the input field must hold.
+            timeout (int): The maximum time in seconds to wait (default: 20).
+        """
+        WebDriverWait(self, timeout).until(
+            lambda driver: self.__has_value(driver, by, element, value)
+        )
+
+    @staticmethod
+    def __has_value(driver: WebDriver, by: str, element: str, value: str):
+        try:
+            return driver.find_element(by, element).get_attribute("value") == value
+        except StaleElementReferenceException:
+            return False
 
     def wait_for(self, condition, timeout=20):
         """Waits for a given condition to be true.
@@ -150,22 +211,35 @@ class MiminetTester(WebDriver):
         except TimeoutException:
             raise Exception(f"Modal dialog {element} wasn't opened.")
         finally:
-            # TODO change it to wait_until_disappear when modal dialog will be fixed
-            self.wait_for(
-                lambda driver: not driver.find_element(by, element).is_displayed(),
-                timeout=5,
-            )
+            # EC.invisibility_of_element_located treats a stale element (e.g. while
+            # the modal-close animation removes the dialog) as already invisible,
+            # so the close is awaited without racing the DOM removal.
+            self.wait_until_disappear(by, element, timeout=5)
 
     def select_by_value(self, by: str, element: str, value: str):
         """Selects an option in a select element by its value.
 
+        Re-finds the select element on each attempt so a stale element caused by
+        a page re-render is not treated as a failure.
+
         Args:
-            by (str): The locator strategy (e.g., By.ID, By.XPATH).
+            by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             value: The value attribute of the option to select.
         """
-        select = Select(self.find_element(by, element))
-        select.select_by_value(value)
+        deadline = time.monotonic() + 20
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutException(
+                    f"Unable to select value {value} in {element} within 20 seconds."
+                )
+            try:
+                select = Select(self.find_element(by, element))
+                select.select_by_value(value)
+                return
+            except StaleElementReferenceException:
+                continue
 
     def get_logs(self, logs_filter=None):
         """

--- a/front/tests/test_job_edit.py
+++ b/front/tests/test_job_edit.py
@@ -1,5 +1,3 @@
-import time
-
 from conftest import MiminetTester
 from selenium.webdriver.common.by import By
 from utils.locators import Location
@@ -40,20 +38,19 @@ class TestJobEdit:
 
         # Open config and click edit button for the job
         config1 = network.open_node_config(host1_id)
-        edit_button = selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, f"#config_host_job_edit_{initial_job_id}"
         )
-        edit_button.click()
 
-        time.sleep(0.3)
-
-        # Check that job field is pre-filled with original value
+        # Job field is pre-filled with original value (no fixed sleep)
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            "192.168.1.2",
+        )
         ping_field = selenium.find_element(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector
         )
-        assert (
-            ping_field.get_attribute("value") == "192.168.1.2"
-        ), "Original ping target should be pre-filled"
 
         # Modify the job
         ping_field.clear()
@@ -113,11 +110,16 @@ class TestJobEdit:
 
         # Edit one of the jobs
         config1 = network.open_node_config(host1_id)
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, f"#config_host_job_edit_{first_job_id}"
-        ).click()
+        )
 
-        time.sleep(0.3)
+        # Wait for the pre-filled value before clearing it (no fixed sleep)
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            first_job_original_ip,
+        )
 
         # Modify the ping target
         ping_field = selenium.find_element(
@@ -177,15 +179,18 @@ class TestJobEdit:
 
         assert len(network.jobs) == 3, "Should have 3 jobs initially"
 
-        # Store original job IDs
+        # Store original job IDs and values
         job_ids = [job["id"] for job in network.jobs]
+        job_values = {job["id"]: job["arg_1"] for job in network.jobs}
 
         # Edit first job
         config_host = network.open_node_config(host_id)
-        selenium.find_element(
-            By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[0]}"
-        ).click()
-        time.sleep(0.3)
+        selenium.wait_and_click(By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[0]}")
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            job_values[job_ids[0]],
+        )
 
         ping_field = selenium.find_element(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector
@@ -196,10 +201,12 @@ class TestJobEdit:
 
         # Edit second job
         config_host = network.open_node_config(host_id)
-        selenium.find_element(
-            By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[1]}"
-        ).click()
-        time.sleep(0.3)
+        selenium.wait_and_click(By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[1]}")
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            job_values[job_ids[1]],
+        )
 
         ping_field = selenium.find_element(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector

--- a/front/tests/utils/networks.py
+++ b/front/tests/utils/networks.py
@@ -96,9 +96,15 @@ class MiminetTestNetwork:
         (str) : Network URL
         """
         self.__selenium.get(HOME_PAGE)
-        self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR, Location.MyNetworks.NEW_NETWORK_BUTTON.selector
-        ).click()
+        )
+
+        # Wait for the frontend to finish creating the network and navigate to
+        # its editor page before capturing the URL (no navigation race).
+        self.__selenium.wait_until_appear(
+            By.CSS_SELECTOR, Location.Network.MAIN_PANEL.selector
+        )
 
         self.__url = self.__selenium.current_url
 
@@ -161,8 +167,12 @@ class MiminetTestNetwork:
 
         local_x, local_y = self.__calc_panel_offset(panel, x, y)
 
-        device_button = self.__selenium.find_element(*node_type)
-        self.__selenium.drag_and_drop(device_button, panel, local_x, local_y)
+        self.__selenium.drag_and_drop(
+            node_type,
+            (By.CSS_SELECTOR, Location.Network.MAIN_PANEL.selector),
+            local_x,
+            local_y,
+        )
         self.__selenium.wait_for(lambda _: old_nodes_len < len(self.nodes), timeout=5)
         return len(self.nodes) - 1
 


### PR DESCRIPTION
fixes #464 (`dhcp_two_host` / `vlan_with_vxlan` flake family).

Root cause of the DHCP animation mismatch:
1. `_has_meaningful_packets` treated a DHCP **Discover-only** capture as
   meaningful, so the retry loop never kicked in even though the client never
   got an Offer/Ack.
2. `dhcp_server` returned right after spawning dnsmasq, so a DHCP client that
   starts immediately after could race the server's socket bind.

Changes:
- `tasks.py`: the retry predicate is now protocol-aware — a capture with only
  `DHCP Discover` and no server reply (Offer/Request/Ack) is not meaningful
  and the emulation is retried.
- `jobs.py`: after `start_daemon`, wait for dnsmasq to actually bind its
  sockets (`daemon.pids` probe, 15s cap) before returning.

Verified locally: py_compile, black, flake8, mypy.