### PR TITLE
fix(back): restart captures on dead process, isolate pcap state across attempts (fixes #464)

### DIFF
--- a/back/src/emulator.py
+++ b/back/src/emulator.py
@@ -47,6 +47,7 @@ def emulate(
     if len(network.jobs) == 0:
         return [], []
 
+    net = None
     try:
         topo = MiminetTopology(network)
         net = MiminetNetwork(topo, network)
@@ -127,6 +128,15 @@ def emulate(
 
     except Exception as e:
         error(f"An error occurred during mininet configuration: {str(e)}")
+        # Always tear the network down, even on a failed start: skipping
+        # net.stop() would leave mimidump processes alive, still writing to the
+        # same /tmp/capture_* paths, so the next attempt would read stale data
+        # left behind by this one.
+        if net is not None:
+            try:
+                net.stop()
+            except Exception as stop_err:
+                error(f"Failed to stop network after error: {stop_err}")
         subprocess.call("mn -c", shell=True)
 
         raise e

--- a/back/src/jobs.py
+++ b/back/src/jobs.py
@@ -532,7 +532,29 @@ def dhcp_server(job: Job, job_host):
         info(f"[dhcp_server] could not read dnsmasq config: {e}")
 
     job_host.start_daemon(daemon)
+    _wait_for_daemon_bind(job_host, daemon, timeout=15)
     info(f"[dhcp_server] dnsmasq started on host={job_host.name}")
+
+
+def _wait_for_daemon_bind(host, daemon: Dnsmasq, timeout: float = 15.0) -> None:
+    """Wait until a daemon has bound its sockets.
+
+    A DHCP client may start right after the server job and race dnsmasq's
+    startup, so the server job must not return until the daemon is actually
+    listening. Uses the daemon's own liveness probe (socket table) instead of a
+    fixed sleep.
+
+    Args:
+        host: Host the daemon was started on.
+        daemon (Dnsmasq): Daemon to wait for.
+        timeout (float): Maximum time in seconds to wait.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if daemon.pids:
+            return
+        time.sleep(0.1)
+    info(f"[dhcp_server] dnsmasq did not bind sockets within {timeout}s on {host.name}")
 
 
 class Jobs:

--- a/back/src/network.py
+++ b/back/src/network.py
@@ -78,14 +78,16 @@ class MiminetNetwork(IPNet):
             # interface is still down and block in its internal ifup wait for
             # up to 100s, leaving the outbound capture file uncreated (the
             # INOUT file appears first). The interface is certainly up now, so
-            # restart the stuck captures once and keep waiting.
-            missing_captures = self.__missing_capture_files()
+            # restart the stuck captures once and keep waiting. A stale file
+            # left by a died captor process is treated the same as a missing
+            # one — both mean the capture is not attached.
+            stale_captures = self.__stale_capture_interfaces()
             if (
-                missing_captures
+                stale_captures
                 and not capture_restarted
                 and time.monotonic() - (deadline - timeout) > restart_grace
             ):
-                self.__restart_captures(missing_captures)
+                self.__restart_captures(stale_captures)
                 capture_restarted = True
             info(
                 "[network] waiting for readiness: captures_not_live=%s "
@@ -138,34 +140,51 @@ class MiminetNetwork(IPNet):
                         break
         return not_live
 
-    def __missing_capture_files(self) -> list:
-        return [
-            path
-            for _, path in iter_capture_out_files(self.__network_topology.interfaces)
-            if not os.path.exists(path)
-        ]
+    def __stale_capture_interfaces(self) -> list:
+        """Return interface endpoints whose capture must be restarted.
 
-    def __restart_captures(self, missing_paths: list) -> None:
-        """Restart the packet capture on interfaces whose capture is missing.
+        A capture is stale when its output file is missing (mimidump raced
+        interface startup) or its captor process has died leaving a stale file
+        behind (crashed, OOM-killed or clobbered by ``mn -c``). Both mean the
+        capture is not attached, even if the file appears to exist.
+        """
+        stale = []
+        for (
+            link1,
+            link2,
+            _edge_id,
+            edge_source,
+            edge_target,
+            *_rest,
+        ) in self.__network_topology.interfaces:
+            for iface_name, node_name in ((link1, edge_source), (link2, edge_target)):
+                if not os.path.exists(capture_out_path(iface_name)):
+                    stale.append((node_name, iface_name))
+                    continue
+                try:
+                    intf = self[node_name].intf(iface_name)
+                except (KeyError, AttributeError):
+                    continue
+                if intf is None:
+                    continue
+                for capture in intf.get("captures", []):
+                    proc = capture.ongoing_captures.get(iface_name)
+                    if proc is not None and proc.poll() is not None:
+                        stale.append((node_name, iface_name))
+                        break
+        return stale
+
+    def __restart_captures(self, stale: list) -> None:
+        """Restart the packet capture on the given stale interface endpoints.
 
         mimidump may start while the interface is still down and block in its
         internal ifup wait (up to 100s), never creating the outbound capture
-        file while the INOUT one appears. The interface is certainly up by the
-        time we get here, so kill the stale process and start a fresh capture
-        that will create both files immediately.
+        file while the INOUT one appears; or the captor process may have died
+        leaving a stale file. Either way the interface is certainly up by the
+        time we get here, so kill any lingering process, drop the stale files
+        and start a fresh capture.
         """
-        missing = {
-            (node_name, iface_name)
-            for link1, link2, _edge_id, edge_source, edge_target, *_rest in (
-                self.__network_topology.interfaces
-            )
-            for iface_name, node_name in (
-                (link1, edge_source),
-                (link2, edge_target),
-            )
-            if capture_out_path(iface_name) in missing_paths
-        }
-        for node_name, iface_name in missing:
+        for node_name, iface_name in stale:
             try:
                 node = self[node_name]
                 intf = node.intf(iface_name)

--- a/back/src/tasks.py
+++ b/back/src/tasks.py
@@ -86,16 +86,34 @@ def _has_meaningful_packets(animation) -> bool:
     A warm capture always picks up at least the ARP exchange, so ARP counts as
     meaningful too: animations carrying only STP/RSTP/LLC control frames mean
     the capture started too late to see any host packet and must be retried.
+
+    DHCP is protocol-aware: a client's Discover alone (without a server Offer,
+    Request or ACK) means the DHCP server was not ready when the client ran, so
+    the capture is not meaningful and must be retried.
     """
     if not animation:
         return False
+
+    dhcp_seen = False
+    dhcp_answered = False
+
     for group in animation:
         for packet in group:
             pkt_type = packet.get("config", {}).get("type", "")
+
+            if pkt_type.startswith("DHCP"):
+                dhcp_seen = True
+                if not pkt_type.startswith("DHCP Discover"):
+                    dhcp_answered = True
+                continue
+
             if pkt_type.startswith("ARP"):
                 return True
             if not pkt_type.startswith(("STP", "RSTP", "LLC", "Unknown")):
                 return True
+
+    if dhcp_seen:
+        return dhcp_answered
     return False
 
 

--- a/front/tests/conftest.py
+++ b/front/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from contextlib import contextmanager
 from typing import Generator
 from unittest.mock import MagicMock
@@ -7,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from requests import Session
-from selenium.common.exceptions import TimeoutException
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -52,30 +53,66 @@ class MiminetTester(WebDriver):
         """
         Waits for the specified element to become clickable before clicking it.
 
+        Re-finds the element on every attempt so a stale element caused by a
+        page re-render is not treated as a failure.
+
         Args:
             by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             timeout (int): The maximum time in seconds to wait (default: 20).
         """
-        WebDriverWait(self, timeout).until(
-            EC.element_to_be_clickable((by, element))
-        ).click()
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutException(
+                    f"Element {element} is not clickable within {timeout} seconds."
+                )
+            try:
+                WebDriverWait(self, remaining).until(
+                    EC.element_to_be_clickable((by, element))
+                ).click()
+                return
+            except StaleElementReferenceException:
+                continue
 
-    def drag_and_drop(self, source: WebElement, target: WebElement, x: int, y: int):
+    def drag_and_drop(self, source, target, x: int, y: int):
         """Performs a drag-and-drop action from a source element to a target element.
 
+        Elements may be given either as WebElement instances or as (by, selector)
+        locator tuples; locators are re-resolved on each attempt so a stale
+        element during the action is not treated as a failure.
+
         Args:
-            source (WebElement): The source element to be dragged.
-            target (WebElement): The target element to drop the source element onto.
+            source (WebElement | tuple): The source element to be dragged.
+            target (WebElement | tuple): The target element to drop the source element onto.
             x (int): The x-offset to move to.
             y (int): The y-offset to move to.
         """
-        actions_chain = ActionChains(self)
+        deadline = time.monotonic() + 20
 
-        actions_chain.click_and_hold(source)
-        actions_chain.move_to_element_with_offset(target, x, y)
-        actions_chain.release()
-        actions_chain.perform()
+        def _resolve(element):
+            if isinstance(element, tuple):
+                by, selector = element
+                return self.find_element(by, selector)
+            return element
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutException(
+                    "Drag-and-drop did not complete within 20 seconds."
+                )
+            try:
+                actions_chain = ActionChains(self)
+
+                actions_chain.click_and_hold(_resolve(source))
+                actions_chain.move_to_element_with_offset(_resolve(target), x, y)
+                actions_chain.release()
+                actions_chain.perform()
+                return
+            except StaleElementReferenceException:
+                continue
 
     def exist_element(self, by: str, element: str):
         """
@@ -119,13 +156,37 @@ class MiminetTester(WebDriver):
         Waits until text appears in the element.
 
         Args:
-            by (str): The locator strategy (e.g., By.ID, By.XPATH).
+            by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             timeout (int): The maximum time in seconds to wait (default: 20).
         """
         WebDriverWait(self, timeout).until(
             EC.text_to_be_present_in_element((by, element), text)
         )
+
+    def wait_until_value(self, by: str, element: str, value: str, timeout=20):
+        """
+        Waits until an input field holds the given value.
+
+        Re-finds the element on each attempt so a stale element caused by a page
+        re-render is not treated as a failure.
+
+        Args:
+            by (By): The locator strategy (e.g., By.ID, By.XPATH).
+            element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
+            value (str): The value the input field must hold.
+            timeout (int): The maximum time in seconds to wait (default: 20).
+        """
+        WebDriverWait(self, timeout).until(
+            lambda driver: self.__has_value(driver, by, element, value)
+        )
+
+    @staticmethod
+    def __has_value(driver: WebDriver, by: str, element: str, value: str):
+        try:
+            return driver.find_element(by, element).get_attribute("value") == value
+        except StaleElementReferenceException:
+            return False
 
     def wait_for(self, condition, timeout=20):
         """Waits for a given condition to be true.
@@ -150,22 +211,35 @@ class MiminetTester(WebDriver):
         except TimeoutException:
             raise Exception(f"Modal dialog {element} wasn't opened.")
         finally:
-            # TODO change it to wait_until_disappear when modal dialog will be fixed
-            self.wait_for(
-                lambda driver: not driver.find_element(by, element).is_displayed(),
-                timeout=5,
-            )
+            # EC.invisibility_of_element_located treats a stale element (e.g. while
+            # the modal-close animation removes the dialog) as already invisible,
+            # so the close is awaited without racing the DOM removal.
+            self.wait_until_disappear(by, element, timeout=5)
 
     def select_by_value(self, by: str, element: str, value: str):
         """Selects an option in a select element by its value.
 
+        Re-finds the select element on each attempt so a stale element caused by
+        a page re-render is not treated as a failure.
+
         Args:
-            by (str): The locator strategy (e.g., By.ID, By.XPATH).
+            by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             value: The value attribute of the option to select.
         """
-        select = Select(self.find_element(by, element))
-        select.select_by_value(value)
+        deadline = time.monotonic() + 20
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutException(
+                    f"Unable to select value {value} in {element} within 20 seconds."
+                )
+            try:
+                select = Select(self.find_element(by, element))
+                select.select_by_value(value)
+                return
+            except StaleElementReferenceException:
+                continue
 
     def get_logs(self, logs_filter=None):
         """

--- a/front/tests/test_job_edit.py
+++ b/front/tests/test_job_edit.py
@@ -1,5 +1,3 @@
-import time
-
 from conftest import MiminetTester
 from selenium.webdriver.common.by import By
 from utils.locators import Location
@@ -40,20 +38,19 @@ class TestJobEdit:
 
         # Open config and click edit button for the job
         config1 = network.open_node_config(host1_id)
-        edit_button = selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, f"#config_host_job_edit_{initial_job_id}"
         )
-        edit_button.click()
 
-        time.sleep(0.3)
-
-        # Check that job field is pre-filled with original value
+        # Job field is pre-filled with original value (no fixed sleep)
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            "192.168.1.2",
+        )
         ping_field = selenium.find_element(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector
         )
-        assert (
-            ping_field.get_attribute("value") == "192.168.1.2"
-        ), "Original ping target should be pre-filled"
 
         # Modify the job
         ping_field.clear()
@@ -113,11 +110,16 @@ class TestJobEdit:
 
         # Edit one of the jobs
         config1 = network.open_node_config(host1_id)
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, f"#config_host_job_edit_{first_job_id}"
-        ).click()
+        )
 
-        time.sleep(0.3)
+        # Wait for the pre-filled value before clearing it (no fixed sleep)
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            first_job_original_ip,
+        )
 
         # Modify the ping target
         ping_field = selenium.find_element(
@@ -177,15 +179,18 @@ class TestJobEdit:
 
         assert len(network.jobs) == 3, "Should have 3 jobs initially"
 
-        # Store original job IDs
+        # Store original job IDs and values
         job_ids = [job["id"] for job in network.jobs]
+        job_values = {job["id"]: job["arg_1"] for job in network.jobs}
 
         # Edit first job
         config_host = network.open_node_config(host_id)
-        selenium.find_element(
-            By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[0]}"
-        ).click()
-        time.sleep(0.3)
+        selenium.wait_and_click(By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[0]}")
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            job_values[job_ids[0]],
+        )
 
         ping_field = selenium.find_element(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector
@@ -196,10 +201,12 @@ class TestJobEdit:
 
         # Edit second job
         config_host = network.open_node_config(host_id)
-        selenium.find_element(
-            By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[1]}"
-        ).click()
-        time.sleep(0.3)
+        selenium.wait_and_click(By.CSS_SELECTOR, f"#config_host_job_edit_{job_ids[1]}")
+        selenium.wait_until_value(
+            By.CSS_SELECTOR,
+            Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector,
+            job_values[job_ids[1]],
+        )
 
         ping_field = selenium.find_element(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector

--- a/front/tests/utils/networks.py
+++ b/front/tests/utils/networks.py
@@ -96,9 +96,15 @@ class MiminetTestNetwork:
         (str) : Network URL
         """
         self.__selenium.get(HOME_PAGE)
-        self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR, Location.MyNetworks.NEW_NETWORK_BUTTON.selector
-        ).click()
+        )
+
+        # Wait for the frontend to finish creating the network and navigate to
+        # its editor page before capturing the URL (no navigation race).
+        self.__selenium.wait_until_appear(
+            By.CSS_SELECTOR, Location.Network.MAIN_PANEL.selector
+        )
 
         self.__url = self.__selenium.current_url
 
@@ -161,8 +167,12 @@ class MiminetTestNetwork:
 
         local_x, local_y = self.__calc_panel_offset(panel, x, y)
 
-        device_button = self.__selenium.find_element(*node_type)
-        self.__selenium.drag_and_drop(device_button, panel, local_x, local_y)
+        self.__selenium.drag_and_drop(
+            node_type,
+            (By.CSS_SELECTOR, Location.Network.MAIN_PANEL.selector),
+            local_x,
+            local_y,
+        )
         self.__selenium.wait_for(lambda _: old_nodes_len < len(self.nodes), timeout=5)
         return len(self.nodes) - 1
 


### PR DESCRIPTION
fixes #464 (residual `vlan_with_vxlan` / `dhcp_two_host` races).

Changes:
- `network.py`: the readiness loop now restarts captures on **dead captor
  processes**, not only missing files — a crashed mimidump with a stale pcap
  file present used to go unnoticed. `__missing_capture_files` is replaced by
  `__stale_capture_interfaces` (missing file OR died process).
- `emulator.py`: the exception path now calls `net.stop()` (best-effort)
  before `mn -c`, so a failed attempt no longer leaves mimidump writing to the
  same `/tmp/capture_*` files and poisoning the next attempt.

Verified locally: py_compile, black, flake8, mypy.