### PR TITLE
fix(back): consume ipmininet v1.2.7 strict capture readiness

### DIFF
--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -4,5 +4,5 @@ python-dotenv==1.2.3
 marshmallow_dataclass==8.7.1
 psutil==7.2.2
 netaddr==1.3.0
-ipmininet @ git+https://github.com/mimi-net/ipmininet.git@v1.2.6
+ipmininet @ git+https://github.com/mimi-net/ipmininet.git@v1.2.7
 pytest-timeout==2.4.0

--- a/back/src/net_utils/readiness.py
+++ b/back/src/net_utils/readiness.py
@@ -1,0 +1,29 @@
+"""Pure helpers for the network-readiness gate.
+
+The readiness gate (``MiminetNetwork.__wait_until_ready``) walks the link
+endpoints of a topology and inspects the packet capture attached to each
+interface. The endpoint-walking scaffold used to be duplicated across the
+capture-liveness probe and the capture-restart path; it lives here so the
+decision logic stays in one testable place.
+"""
+
+
+def iter_capture_endpoints(interfaces, get_intf):
+    """Yield ``(node_name, iface_name, intf, captures)`` for every link endpoint
+    that resolves to an interface object.
+
+    ``interfaces`` is the topology's list of ``(link1, link2, edge_id,
+    edge_source, edge_target, ...)`` tuples, where ``linkN`` is the interface
+    name on the ``edge_*`` node. ``get_intf(node_name, iface_name)`` returns
+    the interface object (or ``None``); lookups that raise ``KeyError`` /
+    ``AttributeError`` (node or interface no longer present) are skipped.
+    """
+    for link1, link2, _edge_id, edge_source, edge_target, *_rest in interfaces:
+        for iface_name, node_name in ((link1, edge_source), (link2, edge_target)):
+            try:
+                intf = get_intf(node_name, iface_name)
+            except (KeyError, AttributeError):
+                continue
+            if intf is None:
+                continue
+            yield node_name, iface_name, intf, intf.get("captures", [])

--- a/back/src/network.py
+++ b/back/src/network.py
@@ -4,7 +4,8 @@ import time
 import psutil
 from ipmininet.ipnet import IPNet
 from mininet.log import info
-from net_utils.captures import capture_out_path, capture_paths, iter_capture_out_files
+from net_utils.captures import capture_paths
+from net_utils.readiness import iter_capture_endpoints
 from net_utils.vlan import clean_bridges, has_vlan_interfaces, setup_vlans
 from net_utils.vxlan import (
     iter_vtep_network_interfaces,
@@ -51,8 +52,6 @@ class MiminetNetwork(IPNet):
         # network_configuration_time (even 0).
         self.__wait_until_ready()
 
-        self.__check_files()
-
     def __wait_until_ready(self, timeout: float = 90.0, poll: float = 0.5) -> None:
         """Poll until the emulation environment is really ready.
 
@@ -76,18 +75,17 @@ class MiminetNetwork(IPNet):
                 return
             # mimidump can race interface startup: it may start while the
             # interface is still down and block in its internal ifup wait for
-            # up to 100s, leaving the outbound capture file uncreated (the
-            # INOUT file appears first). The interface is certainly up now, so
-            # restart the stuck captures once and keep waiting. A stale file
-            # left by a died captor process is treated the same as a missing
-            # one — both mean the capture is not attached.
-            stale_captures = self.__stale_capture_interfaces()
+            # up to 100s, leaving the capture unattached. The interface is
+            # certainly up now, so once the grace window has passed restart the
+            # still-not-live captures a single time and keep waiting. A stale
+            # file left by a died captor process is treated the same as a
+            # missing one — both mean the capture is not attached.
             if (
-                stale_captures
+                captures_not_live
                 and not capture_restarted
                 and time.monotonic() - (deadline - timeout) > restart_grace
             ):
-                self.__restart_captures(stale_captures)
+                self.__restart_captures(self.__captures_not_live(timeout=1.0))
                 capture_restarted = True
             info(
                 "[network] waiting for readiness: captures_not_live=%s "
@@ -97,8 +95,12 @@ class MiminetNetwork(IPNet):
             time.sleep(poll)
 
         details = []
-        if self.__captures_not_live():
-            details.append("captures not live")
+        captures_not_live = self.__captures_not_live()
+        if captures_not_live:
+            details.append(
+                "captures not live: %s"
+                % ", ".join(iface for _node, iface in captures_not_live)
+            )
         if self.__unconverged_switches():
             details.append("STP/RSTP switches not forwarding")
         if self.__unreachable_vtep_targets():
@@ -108,91 +110,49 @@ class MiminetNetwork(IPNet):
             % (timeout, ", ".join(details))
         )
 
-    def __captures_not_live(self) -> list:
+    def __captures_not_live(self, timeout: float = 0.1) -> list:
         """Return interface endpoints whose capture is not confirmed live yet.
 
-        Consumes ipmininet's ``NetworkCapture.wait_until_capturing`` (mimidump
-        READY signal, file-existence fallback) so jobs start only after the
-        capture is actually attached — not just that its output file exists.
+        Consumes ipmininet's ``NetworkCapture.wait_until_capturing`` in strict
+        mode (mimidump READY signal, or a pcap file that keeps growing past its
+        header) so jobs start only after the capture is actually attached — not
+        just because its output file exists. The default ``timeout`` is a short
+        per-poll gate; callers that need a definitive answer (the restart path)
+        pass a longer one.
         """
         not_live = []
-        for (
-            link1,
-            link2,
-            _edge_id,
-            edge_source,
-            edge_target,
-            *_rest,
-        ) in self.__network_topology.interfaces:
-            for iface_name, node_name in (
-                (link1, edge_source),
-                (link2, edge_target),
-            ):
-                try:
-                    intf = self[node_name].intf(iface_name)
-                except (KeyError, AttributeError):
-                    continue
-                if intf is None:
-                    continue
-                for capture in intf.get("captures", []):
-                    if not capture.wait_until_capturing(iface_name, timeout=0.1):
-                        not_live.append(iface_name)
-                        break
+        for node_name, iface_name, _intf, captures in iter_capture_endpoints(
+            self.__network_topology.interfaces,
+            lambda node_name, iface_name: self[node_name].intf(iface_name),
+        ):
+            for capture in captures:
+                if not capture.wait_until_capturing(
+                    iface_name, timeout=timeout, strict=True
+                ):
+                    not_live.append((node_name, iface_name))
+                    break
         return not_live
-
-    def __stale_capture_interfaces(self) -> list:
-        """Return interface endpoints whose capture must be restarted.
-
-        A capture is stale when its output file is missing (mimidump raced
-        interface startup) or its captor process has died leaving a stale file
-        behind (crashed, OOM-killed or clobbered by ``mn -c``). Both mean the
-        capture is not attached, even if the file appears to exist.
-        """
-        stale = []
-        for (
-            link1,
-            link2,
-            _edge_id,
-            edge_source,
-            edge_target,
-            *_rest,
-        ) in self.__network_topology.interfaces:
-            for iface_name, node_name in ((link1, edge_source), (link2, edge_target)):
-                if not os.path.exists(capture_out_path(iface_name)):
-                    stale.append((node_name, iface_name))
-                    continue
-                try:
-                    intf = self[node_name].intf(iface_name)
-                except (KeyError, AttributeError):
-                    continue
-                if intf is None:
-                    continue
-                for capture in intf.get("captures", []):
-                    proc = capture.ongoing_captures.get(iface_name)
-                    if proc is not None and proc.poll() is not None:
-                        stale.append((node_name, iface_name))
-                        break
-        return stale
 
     def __restart_captures(self, stale: list) -> None:
         """Restart the packet capture on the given stale interface endpoints.
 
         mimidump may start while the interface is still down and block in its
-        internal ifup wait (up to 100s), never creating the outbound capture
-        file while the INOUT one appears; or the captor process may have died
-        leaving a stale file. Either way the interface is certainly up by the
-        time we get here, so kill any lingering process, drop the stale files
-        and start a fresh capture.
+        internal ifup wait (up to 100s), never attaching the capture; or the
+        captor process may have died leaving a stale file behind. Either way
+        the interface is certainly up by the time we get here, so kill any
+        lingering process, drop the stale files and start a fresh capture.
         """
+        endpoints = {
+            (node_name, iface_name): (intf, captures)
+            for node_name, iface_name, intf, captures in iter_capture_endpoints(
+                self.__network_topology.interfaces,
+                lambda node_name, iface_name: self[node_name].intf(iface_name),
+            )
+        }
         for node_name, iface_name in stale:
-            try:
-                node = self[node_name]
-                intf = node.intf(iface_name)
-            except (KeyError, AttributeError):
+            if (node_name, iface_name) not in endpoints:
                 continue
-            if intf is None:
-                continue
-            captures = intf.get("captures", [])
+            intf, captures = endpoints[(node_name, iface_name)]
             for capture in captures:
                 proc = capture.ongoing_captures.get(iface_name)
                 if proc is not None and proc.poll() is None:
@@ -397,21 +357,6 @@ class MiminetNetwork(IPNet):
         )
         super().stop()
         info("[network.stop] done\n")
-
-    def __check_files(self):
-        """Check that every interface capture file exists."""
-        for iface, path in iter_capture_out_files(self.__network_topology.interfaces):
-            if not os.path.exists(path):
-                self.__clear_files()
-                raise ValueError(f"No capture for interface '{iface}'.")
-
-    def __clear_files(self):
-        """Remove pcap files."""
-        for link1, link2, *_ in self.__network_topology.interfaces:
-            for iface in (link1, link2):
-                for f in capture_paths(iface):
-                    if os.path.exists(f):
-                        os.remove(f)
 
     def __clean_services(self):
         """

--- a/back/tests/test_network_ready.py
+++ b/back/tests/test_network_ready.py
@@ -1,0 +1,324 @@
+"""Unit tests for the capture-readiness gate.
+
+The gate consumes ipmininet's ``NetworkCapture.wait_until_capturing`` in strict
+mode (mimidump READY signal, or a pcap file that keeps growing past its header).
+These tests mirror the strict-mode matrix from ipmininet (mimi-net/ipmininet
+PR #30) at the miminet orchestration level, using fakes so they run rootless
+and dependency-free.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from src.net_utils.captures import capture_paths
+from src.net_utils.readiness import iter_capture_endpoints
+from src.network import MiminetNetwork
+
+
+# ---------------- Fakes ---------------- #
+
+
+class FakeNode:
+    def __init__(self, intfs):
+        self._intfs = intfs
+
+    def intf(self, name):
+        return self._intfs.get(name)
+
+
+class FakeCapture:
+    def __init__(self, live, iface):
+        self.live = live
+        self.calls = []
+        self.ongoing_captures = {}
+        self.started = []
+
+    def wait_until_capturing(self, iface_name, timeout=0.1, strict=False):
+        self.calls.append((iface_name, timeout, strict))
+        return self.live
+
+    def start(self, intf):
+        self.started.append(intf)
+
+
+class FakeProc:
+    def __init__(self):
+        self.killed = False
+        self.waited = False
+
+    def poll(self):
+        return None
+
+    def kill(self):
+        self.killed = True
+
+    def wait(self):
+        self.waited = True
+
+
+def make_intf(captures):
+    return {"captures": captures}
+
+
+def make_net(interfaces, intfs):
+    net = MiminetNetwork.__new__(MiminetNetwork)
+    setattr(
+        net,
+        "_MiminetNetwork__network_topology",
+        SimpleNamespace(interfaces=interfaces),
+    )
+    setattr(net, "_MiminetNetwork__network_schema", SimpleNamespace(nodes=[]))
+    net.nameToNode = {node: FakeNode(ifs) for node, ifs in intfs.items()}
+    return net
+
+
+def monotonic_clock():
+    state = {"t": 0.0}
+
+    def tick():
+        state["t"] += 0.1
+        return state["t"]
+
+    return tick
+
+
+def wait_until_ready(net, timeout=1.0, poll=0.1):
+    return getattr(net, "_MiminetNetwork__wait_until_ready")(timeout=timeout, poll=poll)
+
+
+def captures_not_live(net, timeout=0.1):
+    return getattr(net, "_MiminetNetwork__captures_not_live")(timeout=timeout)
+
+
+def restart_captures(net, stale):
+    return getattr(net, "_MiminetNetwork__restart_captures")(stale)
+
+
+# ---------------- iter_capture_endpoints ---------------- #
+
+
+def test_iter_capture_endpoints_visits_every_endpoint():
+    interfaces = [
+        ("l1a", "l1b", "edge_1", "host1", "router1", 0, 0),
+        ("l2a", "l2b", "edge_2", "host1", "router1", 0, 0),
+    ]
+    intfs = {
+        "host1": {"l1a": make_intf(["c1a"]), "l2a": make_intf(["c2a"])},
+        "router1": {"l1b": make_intf(["c1b"]), "l2b": make_intf(["c2b"])},
+    }
+
+    def get_intf(node_name, iface_name):
+        return intfs.get(node_name, {}).get(iface_name)
+
+    got = list(iter_capture_endpoints(interfaces, get_intf))
+    assert [(node, iface) for node, iface, _intf, _caps in got] == [
+        ("host1", "l1a"),
+        ("router1", "l1b"),
+        ("host1", "l2a"),
+        ("router1", "l2b"),
+    ]
+    assert [caps for _node, _iface, _intf, caps in got] == [
+        ["c1a"],
+        ["c1b"],
+        ["c2a"],
+        ["c2b"],
+    ]
+
+
+def test_iter_capture_endpoints_skips_missing_interfaces():
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+    intfs = {"host1": {"l1a": make_intf(["c"])}}
+
+    def get_intf(node_name, iface_name):
+        return intfs.get(node_name, {}).get(iface_name)
+
+    got = list(iter_capture_endpoints(interfaces, get_intf))
+    assert [(node, iface) for node, iface, _intf, _caps in got] == [("host1", "l1a")]
+
+
+def test_iter_capture_endpoints_ignores_lookup_errors():
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+
+    def get_intf(node_name, iface_name):
+        if node_name == "host1":
+            raise KeyError(node_name)
+        if iface_name == "l1b":
+            raise AttributeError(iface_name)
+        return None
+
+    assert list(iter_capture_endpoints(interfaces, get_intf)) == []
+
+
+# ---------------- __captures_not_live strict matrix ---------------- #
+
+
+@pytest.mark.parametrize(
+    ("live", "expected"),
+    [
+        pytest.param(True, [], id="ready-signal-live"),
+        pytest.param(False, [("host1", "l1a")], id="bare-file-not-live"),
+        pytest.param(True, [], id="growing-file-live"),
+        pytest.param(False, [("host1", "l1a")], id="dead-process-not-live"),
+        pytest.param(False, [("host1", "l1a")], id="missing-file-not-live"),
+    ],
+)
+def test_captures_not_live_strict_gate(live, expected):
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+    capture = FakeCapture(live=live, iface="l1a")
+    intfs = {
+        "host1": {"l1a": make_intf([capture])},
+        "router1": {"l1b": make_intf([])},
+    }
+    net = make_net(interfaces, intfs)
+
+    assert captures_not_live(net) == expected
+    assert capture.calls == [("l1a", 0.1, True)]
+
+
+def test_captures_not_live_passes_restart_timeout():
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+    capture = FakeCapture(live=False, iface="l1a")
+    intfs = {
+        "host1": {"l1a": make_intf([capture])},
+        "router1": {"l1b": make_intf([])},
+    }
+    net = make_net(interfaces, intfs)
+
+    assert captures_not_live(net, timeout=1.0) == [("host1", "l1a")]
+    assert capture.calls == [("l1a", 1.0, True)]
+
+
+def test_captures_not_live_any_capture_fails():
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+    good = FakeCapture(live=True, iface="l1a")
+    bad = FakeCapture(live=False, iface="l1a")
+    intfs = {
+        "host1": {"l1a": make_intf([good, bad])},
+        "router1": {"l1b": make_intf([])},
+    }
+    net = make_net(interfaces, intfs)
+
+    assert captures_not_live(net) == [("host1", "l1a")]
+    assert good.calls == [("l1a", 0.1, True)]
+    assert bad.calls == [("l1a", 0.1, True)]
+
+
+# ---------------- __restart_captures ---------------- #
+
+
+def test_restart_captures_kills_removes_restarts():
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+    capture = FakeCapture(live=False, iface="l1a")
+    proc = FakeProc()
+    capture.ongoing_captures = {"l1a": proc}
+    intf = make_intf([capture])
+    intfs = {
+        "host1": {"l1a": intf},
+        "router1": {"l1b": make_intf([])},
+    }
+    net = make_net(interfaces, intfs)
+
+    with mock.patch("src.network.os.path.exists", return_value=True), mock.patch(
+        "src.network.os.remove"
+    ) as remove_mock, mock.patch("src.network.info"):
+        restart_captures(net, [("host1", "l1a")])
+
+    assert proc.killed
+    assert proc.waited
+    assert capture.ongoing_captures == {}
+    assert capture.started == [intf]
+    assert {call.args[0] for call in remove_mock.call_args_list} == set(
+        capture_paths("l1a")
+    )
+
+
+def test_restart_captures_skips_unknown_endpoints():
+    interfaces = [("l1a", "l1b", "edge_1", "host1", "router1", 0, 0)]
+    capture = FakeCapture(live=False, iface="l1a")
+    intfs = {
+        "host1": {"l1a": make_intf([capture])},
+        "router1": {"l1b": make_intf([])},
+    }
+    net = make_net(interfaces, intfs)
+
+    with mock.patch("src.network.os.path.exists", return_value=True), mock.patch(
+        "src.network.os.remove"
+    ) as remove_mock, mock.patch("src.network.info"):
+        restart_captures(net, [("ghost", "nope")])
+
+    assert not capture.started
+    remove_mock.assert_not_called()
+
+
+# ---------------- __wait_until_ready orchestration ---------------- #
+
+
+def test_wait_until_ready_all_live_returns():
+    net = MiminetNetwork.__new__(MiminetNetwork)
+    with mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=[]
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
+    ), mock.patch(
+        "src.network.time.monotonic", return_value=0.0
+    ), mock.patch(
+        "src.network.time.sleep"
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__restart_captures"
+    ) as restart:
+        wait_until_ready(net)
+
+    restart.assert_not_called()
+
+
+def test_wait_until_ready_timeout_lists_captures():
+    net = MiminetNetwork.__new__(MiminetNetwork)
+    not_live = [("host1", "l1a"), ("router1", "l1b")]
+    with mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=not_live
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
+    ), mock.patch(
+        "src.network.time.monotonic", side_effect=monotonic_clock()
+    ), mock.patch(
+        "src.network.time.sleep"
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__restart_captures"
+    ) as restart:
+        with pytest.raises(TimeoutError) as excinfo:
+            wait_until_ready(net)
+
+    assert "captures not live: l1a, l1b" in str(excinfo.value)
+    restart.assert_not_called()
+
+
+def test_wait_until_ready_restarts_once_after_grace():
+    net = MiminetNetwork.__new__(MiminetNetwork)
+    not_live = [("host1", "l1a")]
+    with mock.patch.dict(
+        "src.network.os.environ", {"MIMINET_CAPTURE_RESTART_GRACE": "0.0"}
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=not_live
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
+    ), mock.patch(
+        "src.network.time.monotonic", side_effect=monotonic_clock()
+    ), mock.patch(
+        "src.network.time.sleep"
+    ), mock.patch.object(
+        MiminetNetwork, "_MiminetNetwork__restart_captures"
+    ) as restart:
+        with pytest.raises(TimeoutError):
+            wait_until_ready(net)
+
+    restart.assert_called_once()
+    args, _kwargs = restart.call_args
+    assert args[0] == not_live


### PR DESCRIPTION
## Summary

Bump `ipmininet` to **v1.2.7**, which adds strict mode to `NetworkCapture.wait_until_capturing` (mimi-net/ipmininet PR #30): a capture counts as live only on the mimidump READY signal or a pcap file that keeps growing past its header — bare file existence no longer counts.

The back's readiness gate now consumes that feature instead of re-implementing the dead-process/missing-file/stale-file proxy locally.

## Changes

- `back/requirements.txt`: pin `ipmininet` `@v1.2.6` → `@v1.2.7` (runtime diff is `overlay.py` only, backward compatible).
- `back/src/network.py`:
  - `__captures_not_live` gates on `wait_until_capturing(..., strict=True)`; the per-poll probe keeps the `0.1s` timeout, the restart path uses `1.0s`.
  - **Drop `__stale_capture_interfaces`** (~35 lines) — strict mode subsumes its `os.path.exists` + `proc.poll()` proxy.
  - **Widen the restart trigger**: after the grace window (`MIMINET_CAPTURE_RESTART_GRACE`, default `2.0s`), any still-not-live capture is restarted a single time (one-shot guard kept).
  - **Drop `__check_files` / `__clear_files`** — strict liveness guarantees the capture file exists; a readiness `TimeoutError` now lists the offending interfaces instead.
  - Extract the triplicated endpoint-walking loop into `net_utils.readiness.iter_capture_endpoints`.
- `back/src/net_utils/readiness.py` (new): pure, testable endpoint-iteration helper.
- `back/tests/test_network_ready.py` (new): rootless unit tests mirroring the strict-mode matrix (READY / bare-file / growth / dead-process / missing), the restart-once-after-grace semantics, and the restart mechanics.

## Why

Removes the ~100 lines of hand-rolled staleness detection that the upstream feature now provides, makes the readiness gate stricter (starts jobs only when captures are genuinely attached), and keeps the restart path bounded to a single restart.
