### PR TITLE
ci: run full test nightly to surface flakes

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -1,6 +1,10 @@
 name: Full test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 2 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds a nightly schedule trigger for the full E2E suite so flaky tests surface on a cadence independent of PR traffic. Schedule events fire only on the default branch; PR/push behavior unchanged.