### PR TITLE
feat(bench): emulation benchmark harness

### DIFF
--- a/back/bench/bench.py
+++ b/back/bench/bench.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""bench.py — measure Miminet emulation cost per network.
+
+Drives the real emulation path (MiminetTopology -> MiminetNetwork ->
+jobs -> create_animation) and records, per network JSON:
+
+  * wall-clock per phase: net.start(), each job, net.stop(), pcap parse
+    (create_animation)
+  * process-tree peak RSS + CPU time (user+sys) of this process and all
+    children (hosts, mimidump, routers)
+  * ovs-vswitchd RSS delta (baseline before run, after run)
+
+Run inside the emulation container with PYTHONPATH pointing at ../src:
+
+    PYTHONPATH=/repo/back/src python3 /repo/back/bench/bench.py \
+        --networks /repo/back/tests/test_json --repeats 1 --out /repo/.bench/report.json
+"""
+
+import argparse
+import glob
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+SRC_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src")
+)
+sys.path.insert(0, SRC_DIR)
+
+import psutil  # noqa: E402
+from mininet.log import setLogLevel  # noqa: E402
+
+from emulator import create_animation, execute_job  # noqa: E402
+from network import MiminetNetwork  # noqa: E402
+from network_topology import MiminetTopology  # noqa: E402
+import tasks  # noqa: E402
+
+
+def setup():
+    if os.name == "posix":
+        signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+    setLogLevel("info")
+
+
+def cleanup_pcap_files():
+    for f in glob.glob("/tmp/capture_*.pcapng"):
+        try:
+            os.remove(f)
+        except OSError:
+            pass
+
+
+def cleanup_emulation():
+    subprocess.call(
+        "mn -c", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+
+
+def ovs_vswitchd_rss():
+    """Return current RSS (bytes) of the ovs-vswitchd daemon, or None."""
+    for proc in psutil.process_iter(["name"]):
+        try:
+            if proc.info["name"] == "ovs-vswitchd":
+                return proc.memory_info().rss
+        except (
+            psutil.NoSuchProcess,
+            psutil.AccessDenied,
+            psutil.ProcessLookupError,
+            psutil.ZombieProcess,
+        ):
+            continue
+    return None
+
+
+class Sampler:
+    """Background thread sampling process-tree RSS."""
+
+    def __init__(self, interval: float = 0.1):
+        self.interval = interval
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self.peak_rss = 0
+
+    def _run(self):
+        root = psutil.Process()
+        while not self._stop.is_set():
+            try:
+                total = root.memory_info().rss
+                for child in root.children(recursive=True):
+                    try:
+                        total += child.memory_info().rss
+                    except (
+                        psutil.NoSuchProcess,
+                        psutil.AccessDenied,
+                        psutil.ProcessLookupError,
+                        psutil.ZombieProcess,
+                    ):
+                        pass
+                self.peak_rss = max(self.peak_rss, total)
+            except (
+                psutil.NoSuchProcess,
+                psutil.AccessDenied,
+                psutil.ProcessLookupError,
+                psutil.ZombieProcess,
+            ):
+                break
+            self._stop.wait(self.interval)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=10)
+
+
+def load_network(network_json: str):
+    """Load and validate a network JSON like tasks.run_miminet does."""
+    jnet = tasks._filter_unknown_nodes(json.loads(network_json))
+    schema = tasks.get_network_schema()
+    return schema.load(jnet, unknown="include")
+
+
+def run_once(network, name: str = "network"):
+    """Run one emulation, returning the metrics dict."""
+    cleanup_pcap_files()
+    cleanup_emulation()
+    ovs_baseline = ovs_vswitchd_rss()
+
+    topo = MiminetTopology(network)
+    net = MiminetNetwork(topo, network)
+
+    sampler = Sampler()
+    sampler.start()
+    cpu_start = psutil.Process().cpu_times()
+
+    wall_start = time.monotonic()
+    try:
+        net.start()
+        ordered_jobs = sorted(network.jobs, key=lambda j: j.job_id // 100, reverse=True)
+        job_times = {}
+        for job in ordered_jobs:
+            t0 = time.monotonic()
+            execute_job(job, net)
+            job_times[f"{job.host_id}:{job.job_id}:{job.print_cmd}"] = (
+                time.monotonic() - t0
+            )
+        t0 = time.monotonic()
+        net.stop()
+        stop_time = time.monotonic() - t0
+    except Exception:
+        cleanup_emulation()
+        raise
+
+    t0 = time.monotonic()
+    create_animation(topo.interfaces)
+    parse_time = time.monotonic() - t0
+
+    wall = time.monotonic() - wall_start
+    sampler.stop()
+    cpu = psutil.Process().cpu_times()
+    cpu_used = (cpu.user - cpu_start.user) + (cpu.system - cpu_start.system)
+
+    pcap_sizes = {
+        os.path.basename(f): os.path.getsize(f)
+        for f in glob.glob("/tmp/capture_*.pcapng")
+    }
+
+    return {
+        "wall": wall,
+        "stop_time": stop_time,
+        "settle_hit_cap": net.settle_hit_cap,
+        "jobs": job_times,
+        "parse_time": parse_time,
+        "peak_rss": sampler.peak_rss,
+        "cpu_time": cpu_used,
+        "ovs_rss_baseline": ovs_baseline,
+        "ovs_rss_after": ovs_vswitchd_rss(),
+        "pcap_sizes": pcap_sizes,
+        "n_nodes": len(network.nodes),
+        "n_edges": len(network.edges),
+        "n_jobs": len(network.jobs),
+    }
+
+
+def main():
+    setup()
+    parser = argparse.ArgumentParser(description="Miminet emulation benchmark")
+    parser.add_argument(
+        "--networks",
+        required=True,
+        help="dir of *_network.json or comma-separated explicit file list",
+    )
+    parser.add_argument("--repeats", type=int, default=1)
+    parser.add_argument("--out", required=True, help="JSON report output path")
+    parser.add_argument("--quiet", action="store_true", help="suppress per-run prints")
+    args = parser.parse_args()
+
+    src = Path(args.networks)
+    if src.is_dir():
+        paths = sorted(src.glob("*_network.json"))
+    else:
+        paths = [Path(p.strip()) for p in args.networks.split(",") if p.strip()]
+
+    report = {"mode": os.environ.get("BACK_MODE", "boxed"), "networks": {}}
+    for path in paths:
+        name = path.stem.removesuffix("_network")
+        with open(path) as fh:
+            try:
+                network = load_network(fh.read())
+            except Exception as e:
+                report["networks"][name] = [{"error": repr(e)}]
+                print(f"[bench] {name} SKIPPED (load error: {e!r})", flush=True)
+                continue
+        runs = []
+        for i in range(args.repeats):
+            try:
+                metrics = run_once(network, name)
+                runs.append(metrics)
+                if not args.quiet:
+                    print(
+                        f"[bench] {name} run={i} wall={metrics['wall']:.2f}s "
+                        f"peak_rss={metrics['peak_rss'] / 2**20:.1f}MiB "
+                        f"cpu={metrics['cpu_time']:.2f}s",
+                        flush=True,
+                    )
+            except Exception as e:
+                runs.append({"error": repr(e)})
+                print(f"[bench] {name} run={i} FAILED: {e!r}", flush=True)
+        report["networks"][name] = runs
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, "w") as fh:
+        json.dump(report, fh, indent=2)
+    print(f"[bench] report written to {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/back/bench/examples/first_and_last_ip_address_network.json
+++ b/back/bench/examples/first_and_last_ip_address_network.json
@@ -1,0 +1,171 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lihdgwl5rmalfspvpag",
+                    "id": "iface_78340542",
+                    "ip": "192.168.1.0",
+                    "name": "iface_78340542",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 75,
+                "y": 150
+            }
+        },
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw1",
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw1",
+                "label": "l2sw1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lihdgwl5rmalfspvpag",
+                    "id": "l2sw1_1",
+                    "name": "l2sw1_1"
+                },
+                {
+                    "connect": "edge_lihdgx7gcz0jgolby7b",
+                    "id": "l2sw1_2",
+                    "name": "l2sw1_2"
+                },
+                {
+                    "connect": "edge_lihdgxw7cwhixwok2br",
+                    "id": "l2sw1_3",
+                    "name": "l2sw1_3"
+                }
+            ],
+            "position": {
+                "x": 175,
+                "y": 125
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lihdgxw7cwhixwok2br",
+                    "id": "iface_62272758",
+                    "ip": "192.168.1.50",
+                    "name": "iface_62272758",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 250,
+                "y": 75
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_3",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_3",
+                "label": "host_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lihdgx7gcz0jgolby7b",
+                    "id": "iface_27378811",
+                    "ip": "192.168.1.255",
+                    "name": "iface_27378811",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 250,
+                "y": 200
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lihdgwl5rmalfspvpag",
+                "source": "host_1",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lihdgx7gcz0jgolby7b",
+                "source": "host_3",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lihdgxw7cwhixwok2br",
+                "source": "host_2",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "4bc4a6d481ff466bab2babdeeb4b6e9d",
+            "level": 0,
+            "job_id": 2,
+            "host_id": "host_1",
+            "arg_1": "-b",
+            "arg_2": "192.168.1.255",
+            "print_cmd": "ping -c 1 -b 192.168.1.255"
+        },
+        {
+            "id": "900e1b963df44b9ab9b25c7d18cbfa62",
+            "level": 1,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "192.168.1.50",
+            "print_cmd": "ping -c 1 192.168.1.50"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 368.99687500000005,
+        "pan_y": 113.0010416666666
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/icmp_host_unreachable_network.json
+++ b/back/bench/examples/icmp_host_unreachable_network.json
@@ -1,0 +1,129 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.100",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljfn4772zjdx5isydn",
+                    "id": "iface_78746555",
+                    "ip": "192.168.1.1",
+                    "name": "iface_78746555",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 139.25,
+                "y": 171.5
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljfn46dfubr308qfhzl",
+                    "id": "iface_26401212",
+                    "ip": "172.16.12.100",
+                    "name": "iface_26401212",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_ljfn4772zjdx5isydn",
+                    "id": "iface_83666615",
+                    "ip": "192.168.1.100",
+                    "name": "iface_83666615",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 219.75,
+                "y": 79.29906829699233
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "172.16.12.100",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljfn46dfubr308qfhzl",
+                    "id": "iface_12847125",
+                    "ip": "172.16.12.1",
+                    "name": "iface_12847125",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 294.75,
+                "y": 172
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_ljfn46dfubr308qfhzl",
+                "source": "router_1",
+                "target": "host_2",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_ljfn4772zjdx5isydn",
+                "source": "host_1",
+                "target": "router_1",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "c80f34a8d8c4439db5d40bfd1104d81b",
+            "level": 0,
+            "job_id": 4,
+            "host_id": "host_1",
+            "arg_1": 1000,
+            "arg_2": "172.16.12.22",
+            "arg_3": 5555,
+            "print_cmd": "send -s 1000 -p tcp 172.16.12.22:5555"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 419.9885416666666,
+        "pan_y": 192.99947916666662
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/icmp_network_unavailable_network.json
+++ b/back/bench/examples/icmp_network_unavailable_network.json
@@ -1,0 +1,87 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.100",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljfl3rf2q2emh44qjm",
+                    "id": "iface_54356261",
+                    "ip": "192.168.1.1",
+                    "name": "iface_54356261",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 141.75,
+                "y": 163.5
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljfl3rf2q2emh44qjm",
+                    "id": "iface_27118645",
+                    "ip": "192.168.1.100",
+                    "name": "iface_27118645",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 306.7443949076863,
+                "y": 164.29687499999997
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_ljfl3rf2q2emh44qjm",
+                "source": "host_1",
+                "target": "router_1",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "b17444694e574740bd01917b773258f6",
+            "level": 0,
+            "job_id": 4,
+            "host_id": "host_1",
+            "arg_1": 1000,
+            "arg_2": "8.8.4.4",
+            "arg_3": 5555,
+            "print_cmd": "send -s 1000 -p tcp 8.8.4.4:5555"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 271.92526041666656,
+        "pan_y": 23.000260416666663
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/ipip_tunnel_network.json
+++ b/back/bench/examples/ipip_tunnel_network.json
@@ -1,0 +1,249 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "212.220.12.2",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_luwhjn7nn9x220bh3ta",
+                    "id": "iface_31731256",
+                    "ip": "212.220.12.1",
+                    "name": "iface_31731256",
+                    "netmask": 30
+                },
+                {
+                    "connect": "edge_luwhjr6b987231uxai",
+                    "id": "iface_34532004",
+                    "ip": "192.168.1.1",
+                    "name": "iface_34532004",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 75,
+                "y": 150
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_2",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_2",
+                "label": "router_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_luwhjn7nn9x220bh3ta",
+                    "id": "iface_82284025",
+                    "ip": "212.220.12.2",
+                    "name": "iface_82284025",
+                    "netmask": 30
+                },
+                {
+                    "connect": "edge_luwhjnslnoweys6xvt",
+                    "id": "iface_67864584",
+                    "ip": "212.220.12.6",
+                    "name": "iface_67864584",
+                    "netmask": 30
+                }
+            ],
+            "position": {
+                "x": 200,
+                "y": 75
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "212.220.12.6",
+                "label": "router_3",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_3",
+                "label": "router_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_luwhjnslnoweys6xvt",
+                    "id": "iface_24716477",
+                    "ip": "212.220.12.5",
+                    "name": "iface_24716477",
+                    "netmask": 30
+                },
+                {
+                    "connect": "edge_luwhjtmt3g86jf3la4",
+                    "id": "iface_40054476",
+                    "ip": "10.0.0.1",
+                    "name": "iface_40054476",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 325,
+                "y": 175
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.1",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_luwhjr6b987231uxai",
+                    "id": "iface_60663141",
+                    "ip": "192.168.1.2",
+                    "name": "iface_60663141",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 75,
+                "y": 250
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "10.0.0.1",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_luwhjtmt3g86jf3la4",
+                    "id": "iface_52355412",
+                    "ip": "10.0.0.2",
+                    "name": "iface_52355412",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 325,
+                "y": 250
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_luwhjn7nn9x220bh3ta",
+                "source": "router_1",
+                "target": "router_2"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_luwhjnslnoweys6xvt",
+                "source": "router_2",
+                "target": "router_3"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_luwhjr6b987231uxai",
+                "source": "host_1",
+                "target": "router_1"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_luwhjtmt3g86jf3la4",
+                "source": "host_2",
+                "target": "router_3"
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "d524e95df26e44af88a857c746490bb9",
+            "level": 3,
+            "job_id": 105,
+            "host_id": "router_1",
+            "arg_1": "212.220.12.1",
+            "arg_2": "212.220.12.5",
+            "arg_3": "1.1.1.1",
+            "arg_4": "tun0",
+            "print_cmd": "ipip: tun0 from 212.220.12.1 to 212.220.12.5 \ntun0: 1.1.1.1"
+        },
+        {
+            "id": "06ba7158fc0b40e1903254e0740dafb5",
+            "level": 4,
+            "job_id": 102,
+            "host_id": "router_1",
+            "arg_1": "10.0.0.0",
+            "arg_2": 24,
+            "arg_3": "1.1.1.1",
+            "print_cmd": "ip route add 10.0.0.0/24 via 1.1.1.1"
+        },
+        {
+            "id": "46987fef5607422d8e926123e5827fab",
+            "level": 3,
+            "job_id": 105,
+            "host_id": "router_3",
+            "arg_1": "212.220.12.5",
+            "arg_2": "212.220.12.1",
+            "arg_3": "2.2.2.2",
+            "arg_4": "tun0",
+            "print_cmd": "ipip: tun0 from 212.220.12.5 to 212.220.12.1 \ntun0: 2.2.2.2"
+        },
+        {
+            "id": "8f7b1abf34a1471e8588446d015b073e",
+            "level": 4,
+            "job_id": 102,
+            "host_id": "router_3",
+            "arg_1": "192.168.1.0",
+            "arg_2": 24,
+            "arg_3": "2.2.2.2",
+            "print_cmd": "ip route add 192.168.1.0/24 via 2.2.2.2"
+        },
+        {
+            "id": "d7c792d3ac69444aa975630092998c80",
+            "level": 4,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "10.0.0.2",
+            "print_cmd": "ping -c 1 10.0.0.2"
+        }
+    ],
+    "config": {
+        "zoom": 1.8924743227315863,
+        "pan_x": 251.72222095515735,
+        "pan_y": 14.304389317170898
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/multicast_udp_network.json
+++ b/back/bench/examples/multicast_udp_network.json
@@ -1,0 +1,200 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw1",
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw1",
+                "label": "l2sw1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljnlk0kk9197psw1aoj",
+                    "id": "l2sw1_2",
+                    "name": "l2sw1_2"
+                },
+                {
+                    "connect": "edge_ljnlk26metoxvq3e9h",
+                    "id": "l2sw1_3",
+                    "name": "l2sw1_3"
+                },
+                {
+                    "connect": "edge_ljnlk4bm6ffe0hsoygl",
+                    "id": "l2sw1_4",
+                    "name": "l2sw1_4"
+                },
+                {
+                    "connect": "edge_ljnll6cak94so4ltmao",
+                    "id": "l2sw1_1",
+                    "name": "l2sw1_1"
+                }
+            ],
+            "position": {
+                "x": 182.00292439598977,
+                "y": 156
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljnlk0kk9197psw1aoj",
+                    "id": "iface_56228373",
+                    "ip": "192.168.1.1",
+                    "name": "iface_56228373",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 267,
+                "y": 102.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljnlk26metoxvq3e9h",
+                    "id": "iface_57218521",
+                    "ip": "192.168.1.2",
+                    "name": "iface_57218521",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 285,
+                "y": 198
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_3",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_3",
+                "label": "host_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljnlk4bm6ffe0hsoygl",
+                    "id": "iface_28868282",
+                    "ip": "192.168.1.3",
+                    "name": "iface_28868282",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 181,
+                "y": 242
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.100",
+                "label": "Multicast",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_4",
+                "label": "Multicast"
+            },
+            "interface": [
+                {
+                    "connect": "edge_ljnll6cak94so4ltmao",
+                    "id": "iface_61332616",
+                    "ip": "192.168.1.200",
+                    "name": "iface_61332616",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 103,
+                "y": 107.5
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_ljnlk0kk9197psw1aoj",
+                "source": "l2sw1",
+                "target": "host_1"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_ljnlk26metoxvq3e9h",
+                "source": "l2sw1",
+                "target": "host_2"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_ljnlk4bm6ffe0hsoygl",
+                "source": "l2sw1",
+                "target": "host_3"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_ljnll6cak94so4ltmao",
+                "source": "host_4",
+                "target": "l2sw1"
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "dc50d7a93dcb4dcbb4376017dcdc36ff",
+            "level": 0,
+            "job_id": 3,
+            "host_id": "host_4",
+            "arg_1": 2000,
+            "arg_2": "224.16.12.1",
+            "arg_3": 12345,
+            "print_cmd": "send -s 2000 -p udp 224.16.12.1:12345"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 338.0,
+        "pan_y": 125.0
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/nat_2_network.json
+++ b/back/bench/examples/nat_2_network.json
@@ -1,0 +1,277 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.2",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgofmx22um9v6xfm0q",
+                    "id": "iface_02042",
+                    "ip": "192.168.1.1",
+                    "name": "iface_02042",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 38.17546400169729,
+                "y": 64.53089480227483
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.2",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgofmz9vs222f21q6j",
+                    "id": "iface_3203577",
+                    "ip": "192.168.1.1",
+                    "name": "iface_3203577",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 41.98754478893972,
+                "y": 194.33669344269467
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "172.16.0.2",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgofmx22um9v6xfm0q",
+                    "id": "iface_44732175",
+                    "ip": "192.168.1.2",
+                    "name": "iface_44732175",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgofmy4l0iyhv0h2fkac",
+                    "id": "iface_85686184",
+                    "ip": "172.16.0.1",
+                    "name": "iface_85686184",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 169.97466191640646,
+                "y": 63.95278153866573
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "172.16.1.2",
+                "label": "router_2",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_2",
+                "label": "router_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgofmz9vs222f21q6j",
+                    "id": "iface_704342856",
+                    "ip": "192.168.1.2",
+                    "name": "iface_704342856",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgofn12tix61u5t1m17",
+                    "id": "iface_57510705",
+                    "ip": "172.16.1.1",
+                    "name": "iface_57510705",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 175.48180410845129,
+                "y": 194.07284113781247
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_3",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_3",
+                "label": "router_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgofmy4l0iyhv0h2fkac",
+                    "id": "iface_2076423",
+                    "ip": "172.16.0.2",
+                    "name": "iface_2076423",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgofn12tix61u5t1m17",
+                    "id": "iface_1535761",
+                    "ip": "172.16.1.2",
+                    "name": "iface_1535761",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgofn22ep4u1hysps9",
+                    "id": "iface_71873576",
+                    "ip": "10.0.0.2",
+                    "name": "iface_71873576",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 270.56390285005637,
+                "y": 122.868866118641
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "10.0.0.2",
+                "label": "host_3",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_3",
+                "label": "host_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgofn22ep4u1hysps9",
+                    "id": "iface_832047",
+                    "ip": "10.0.0.1",
+                    "name": "iface_832047",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 367.27807851777607,
+                "y": 122.50760841220644
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lgofmx22um9v6xfm0q",
+                "source": "host_1",
+                "target": "router_1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgofmy4l0iyhv0h2fkac",
+                "source": "router_1",
+                "target": "router_3",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgofmz9vs222f21q6j",
+                "source": "host_2",
+                "target": "router_2",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgofn12tix61u5t1m17",
+                "source": "router_2",
+                "target": "router_3",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgofn22ep4u1hysps9",
+                "source": "router_3",
+                "target": "host_3",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "f5cd0fb973f0421f9df684a46ba113a4",
+            "level": 1,
+            "job_id": 101,
+            "host_id": "router_2",
+            "arg_1": "iface_57510705",
+            "print_cmd": "add nat -o iface_57510705 -j masquerad"
+        },
+        {
+            "id": "856565f4c69247dcabe086a19e9c5365",
+            "level": 2,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "10.0.0.1",
+            "print_cmd": "ping -c 1 10.0.0.1"
+        },
+        {
+            "id": "96a04a9081e34dac9cea9c1fbf43992d",
+            "level": 3,
+            "job_id": 1,
+            "host_id": "host_2",
+            "arg_1": "10.0.0.1",
+            "print_cmd": "ping -c 1 10.0.0.1"
+        },
+        {
+            "id": "bbdf1c352a914dbf82b7af11616d26d7",
+            "level": 3,
+            "job_id": 101,
+            "host_id": "router_1",
+            "arg_1": "iface_85686184",
+            "print_cmd": "add nat -o iface_85686184 -j masquerad"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 362.8407564919588,
+        "pan_y": 129.10685170381572
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/ring_of_3_routers_network.json
+++ b/back/bench/examples/ring_of_3_routers_network.json
@@ -1,0 +1,188 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "172.16.12.2",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgrh614p9rm3oina1z",
+                    "id": "iface_8242582",
+                    "ip": "10.0.0.2",
+                    "name": "iface_8242582",
+                    "netmask": 23
+                },
+                {
+                    "connect": "edge_lgrh61z9qmhkpbb04j",
+                    "id": "iface_0056373",
+                    "ip": "172.16.12.1",
+                    "name": "iface_0056373",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgrh63yrefi7qajj7zc",
+                    "id": "iface_548368",
+                    "ip": "169.254.1.1",
+                    "name": "iface_548368",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 169.50073109899745,
+                "y": 97.30004309565558
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "192.168.1.1",
+                "label": "router_2",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_2",
+                "label": "router_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgrh61z9qmhkpbb04j",
+                    "id": "iface_475856",
+                    "ip": "172.16.12.2",
+                    "name": "iface_475856",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgrh637ibb0b5tsf8po",
+                    "id": "iface_2404838",
+                    "ip": "192.168.1.2",
+                    "name": "iface_2404838",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 326,
+                "y": 95.80248009231373
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "169.254.1.1",
+                "label": "router_3",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_3",
+                "label": "router_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgrh637ibb0b5tsf8po",
+                    "id": "iface_0330582",
+                    "ip": "192.168.1.1",
+                    "name": "iface_0330582",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lgrh63yrefi7qajj7zc",
+                    "id": "iface_84644284",
+                    "ip": "169.254.1.2",
+                    "name": "iface_84644284",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 256,
+                "y": 211.296875
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "10.0.0.2",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lgrh614p9rm3oina1z",
+                    "id": "iface_650234",
+                    "ip": "10.0.0.1",
+                    "name": "iface_650234",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 96.9897646140358,
+                "y": 194.9914705116965
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lgrh614p9rm3oina1z",
+                "source": "host_1",
+                "target": "router_1"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgrh61z9qmhkpbb04j",
+                "source": "router_1",
+                "target": "router_2"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgrh637ibb0b5tsf8po",
+                "source": "router_2",
+                "target": "router_3"
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lgrh63yrefi7qajj7zc",
+                "source": "router_3",
+                "target": "router_1"
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "77283bfcdade4535aeebe53001fd8907",
+            "level": 0,
+            "job_id": 2,
+            "host_id": "host_1",
+            "arg_1": "-c 1 -t 5",
+            "arg_2": "12.34.45.67",
+            "print_cmd": "ping -c 1 -t 5 12.34.45.67"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 0.0,
+        "pan_y": 0.0
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/router_network.json
+++ b/back/bench/examples/router_network.json
@@ -1,0 +1,211 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lesvf5huc6d8gstxnrr",
+                    "id": "iface_3062667",
+                    "ip": "10.0.0.1",
+                    "name": "iface_3062667",
+                    "netmask": 24
+                },
+                {
+                    "connect": "edge_lesvf7oacw8sndhyc87",
+                    "id": "iface_10710187",
+                    "ip": "10.0.1.1",
+                    "name": "iface_10710187",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 189.75073109899745,
+                "y": 68.79760609899743
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "10.0.0.1",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lesvf6o4e20oz0jzmok",
+                    "id": "iface_232227",
+                    "ip": "10.0.0.2",
+                    "name": "iface_232227",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 46.75,
+                "y": 73
+            }
+        },
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw1",
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw1",
+                "label": "l2sw1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lesvf5huc6d8gstxnrr",
+                    "id": "l2sw1_1",
+                    "name": "l2sw1_1"
+                },
+                {
+                    "connect": "edge_lesvf6o4e20oz0jzmok",
+                    "id": "l2sw1_2",
+                    "name": "l2sw1_2"
+                }
+            ],
+            "position": {
+                "x": 122.75,
+                "y": 148.5
+            }
+        },
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw2",
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw2",
+                "label": "l2sw2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lesvf7oacw8sndhyc87",
+                    "id": "l2sw2_1",
+                    "name": "l2sw2_1"
+                },
+                {
+                    "connect": "edge_lesvfatzpm68pq2b0c",
+                    "id": "l2sw2_2",
+                    "name": "l2sw2_2"
+                },
+                {
+                    "connect": "edge_lesvffsfobw4r8lpqua",
+                    "id": "l2sw2_3",
+                    "name": "l2sw2_3"
+                },
+                {
+                    "connect": "edge_lesvgfsucnj7mbtxev",
+                    "id": "l2sw2_4",
+                    "name": "l2sw2_4"
+                }
+            ],
+            "position": {
+                "x": 270.25,
+                "y": 147.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "10.0.1.1",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lesvfatzpm68pq2b0c",
+                    "id": "iface_7033245",
+                    "ip": "10.0.1.2",
+                    "name": "iface_7033245",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 319.25,
+                "y": 69.5
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lesvf5huc6d8gstxnrr",
+                "source": "router_1",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lesvf6o4e20oz0jzmok",
+                "source": "host_1",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lesvf7oacw8sndhyc87",
+                "source": "l2sw2",
+                "target": "router_1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lesvfatzpm68pq2b0c",
+                "source": "host_2",
+                "target": "l2sw2",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "efaa418595e64a22bb3e26343ec5f0b0",
+            "level": 0,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "10.0.1.2",
+            "print_cmd": "ping -c 1 10.0.1.2"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 381.60163135334744,
+        "pan_y": 178.095851781433
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/stp_network.json
+++ b/back/bench/examples/stp_network.json
@@ -1,0 +1,217 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw1",
+                "stp": 2,
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw1",
+                "label": "l2sw1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lkcmf2rbpdvfpwx4pgk",
+                    "id": "l2sw1_1",
+                    "name": "l2sw1_1"
+                },
+                {
+                    "connect": "edge_lkcmf5kykka73qdsbef",
+                    "id": "l2sw1_2",
+                    "name": "l2sw1_2"
+                },
+                {
+                    "connect": "edge_lkcno4dhe3ujgetwxw9",
+                    "id": "l2sw1_3",
+                    "name": "l2sw1_3"
+                },
+                {
+                    "connect": "edge_lkcno7y5o12h35kxcnk",
+                    "id": "l2sw1_4",
+                    "name": "l2sw1_4"
+                }
+            ],
+            "position": {
+                "x": 138.5,
+                "y": 140.49902520133674
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lkcmf2rbpdvfpwx4pgk",
+                    "id": "iface_37163725",
+                    "ip": "192.168.1.1",
+                    "name": "iface_37163725",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 53.5,
+                "y": 211.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lkcmf5kykka73qdsbef",
+                    "id": "iface_47414478",
+                    "ip": "192.168.1.2",
+                    "name": "iface_47414478",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 225.5,
+                "y": 214
+            }
+        },
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw2",
+                "stp": 2,
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw2",
+                "label": "l2sw2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lkcno4dhe3ujgetwxw9",
+                    "id": "l2sw2_1",
+                    "name": "l2sw2_1"
+                },
+                {
+                    "connect": "edge_lkcno6t4skmc9oeuz4d",
+                    "id": "l2sw2_2",
+                    "name": "l2sw2_2"
+                }
+            ],
+            "position": {
+                "x": 53.5,
+                "y": 63.00243699665813
+            }
+        },
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw3",
+                "stp": 2,
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw3",
+                "label": "l2sw3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lkcno6t4skmc9oeuz4d",
+                    "id": "l2sw3_1",
+                    "name": "l2sw3_1"
+                },
+                {
+                    "connect": "edge_lkcno7y5o12h35kxcnk",
+                    "id": "l2sw3_2",
+                    "name": "l2sw3_2"
+                }
+            ],
+            "position": {
+                "x": 224.49975630033418,
+                "y": 62.50219329699233
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lkcmf2rbpdvfpwx4pgk",
+                "source": "host_1",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lkcmf5kykka73qdsbef",
+                "source": "host_2",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lkcno4dhe3ujgetwxw9",
+                "source": "l2sw2",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lkcno6t4skmc9oeuz4d",
+                "source": "l2sw2",
+                "target": "l2sw3",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lkcno7y5o12h35kxcnk",
+                "source": "l2sw3",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "8c9cfaf1385247de965eb3bc74ce3580",
+            "level": 0,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "192.168.1.2",
+            "print_cmd": "ping -c 1 192.168.1.2"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 633.0,
+        "pan_y": 124.0
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/switch_and_hub_network.json
+++ b/back/bench/examples/switch_and_hub_network.json
@@ -1,0 +1,240 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "Свитч",
+                "type": "l2_switch",
+                "stp": 0
+            },
+            "data": {
+                "id": "l2sw1",
+                "label": "Свитч"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lecszk09edp01gxyfdw",
+                    "id": "l2sw1_1",
+                    "name": "l2sw1_1"
+                },
+                {
+                    "connect": "edge_lecsztzmmr9hg7nabv",
+                    "id": "l2sw1_2",
+                    "name": "l2sw1_2"
+                },
+                {
+                    "connect": "edge_lect0ujovtnu3vu4k9j",
+                    "id": "l2sw1_3",
+                    "name": "l2sw1_3"
+                }
+            ],
+            "position": {
+                "x": 125,
+                "y": 50
+            }
+        },
+        {
+            "classes": [
+                "l1_hub"
+            ],
+            "config": {
+                "label": "Хаб",
+                "type": "l1_hub"
+            },
+            "data": {
+                "id": "l1hub1",
+                "label": "Хаб"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lecszsmarkkbrnjfxsh",
+                    "id": "l1hub1_1",
+                    "name": "l1hub1_1"
+                },
+                {
+                    "connect": "edge_lecsztzmmr9hg7nabv",
+                    "id": "l1hub1_2",
+                    "name": "l1hub1_2"
+                },
+                {
+                    "connect": "edge_lecszwkj36zl99wxqto",
+                    "id": "l1hub1_3",
+                    "name": "l1hub1_3"
+                }
+            ],
+            "position": {
+                "x": 225,
+                "y": 50
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lecszk09edp01gxyfdw",
+                    "id": "iface_57306012",
+                    "ip": "10.0.0.1",
+                    "name": "iface_57306012",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 25,
+                "y": 0
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lecszsmarkkbrnjfxsh",
+                    "id": "iface_2264405",
+                    "ip": "10.0.0.3",
+                    "name": "iface_2264405",
+                    "netmask": 24
+                },
+                {
+                    "id": "iface_8674634",
+                    "name": "iface_8674634",
+                    "connect": "edge_leodb0i042efyciiaci"
+                }
+            ],
+            "position": {
+                "x": 300,
+                "y": -25
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "label": "host_3",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_3",
+                "label": "host_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lecszwkj36zl99wxqto",
+                    "id": "iface_6176562",
+                    "name": "iface_6176562"
+                }
+            ],
+            "position": {
+                "x": 300,
+                "y": 125
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "label": "host_4",
+                "type": "host",
+                "default_gw": ""
+            },
+            "data": {
+                "id": "host_4",
+                "label": "host_4"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lect0ujovtnu3vu4k9j",
+                    "id": "iface_6631183",
+                    "ip": "10.0.0.3",
+                    "name": "iface_6631183",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 50,
+                "y": 125
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lecszk09edp01gxyfdw",
+                "source": "host_1",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lecszsmarkkbrnjfxsh",
+                "source": "host_2",
+                "target": "l1hub1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lecsztzmmr9hg7nabv",
+                "source": "l2sw1",
+                "target": "l1hub1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lecszwkj36zl99wxqto",
+                "source": "host_3",
+                "target": "l1hub1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lect0ujovtnu3vu4k9j",
+                "source": "host_4",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "d1154b4d26524ae19c8ac0e9e31c976a",
+            "level": 0,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "10.0.0.3",
+            "print_cmd": "ping -c 1 10.0.0.3"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 336.8149505974461,
+        "pan_y": 237.3407923931033
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/tcp_connection_setup_1_network.json
+++ b/back/bench/examples/tcp_connection_setup_1_network.json
@@ -1,0 +1,96 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_liy41odgm0e1irlr14",
+                    "id": "iface_18684825",
+                    "ip": "192.168.1.1",
+                    "name": "iface_18684825",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 102.50926058730094,
+                "y": 131.0294876595635
+            }
+        },
+        {
+            "classes": [
+                "server"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "server_1",
+                "type": "server"
+            },
+            "data": {
+                "id": "server_1",
+                "label": "server_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_liy41odgm0e1irlr14",
+                    "id": "iface_31383756",
+                    "ip": "192.168.1.100",
+                    "name": "iface_31383756",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 308.4951260066837,
+                "y": 175.5571950501279
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_liy41odgm0e1irlr14",
+                "source": "host_1",
+                "target": "server_1",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "2d214bfcaa8e4e129c25bbbca64957f2",
+            "level": 0,
+            "job_id": 4,
+            "host_id": "host_1",
+            "arg_1": 1000,
+            "arg_2": "192.168.1.100",
+            "arg_3": 5555,
+            "print_cmd": "send -s 1000 -p tcp 192.168.1.100:5555"
+        },
+        {
+            "id": "d5e1f7304d884f638ce25a78696b7bb1",
+            "level": 1,
+            "job_id": 201,
+            "host_id": "server_1",
+            "arg_1": "192.168.1.100",
+            "arg_2": 5555,
+            "print_cmd": "nc 192.168.1.100 -l 5555"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 305.9198585346701,
+        "pan_y": 55.98745951065132
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/vlan_network.json
+++ b/back/bench/examples/vlan_network.json
@@ -1,0 +1,267 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw1",
+                "stp": 0,
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw1",
+                "label": "l2sw1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lsvt7j4wwvzphob3csn",
+                    "id": "l2sw1_1",
+                    "name": "l2sw1_1",
+                    "type_connection": 1,
+                    "vlan": [
+                        10,
+                        20
+                    ]
+                },
+                {
+                    "connect": "edge_lsvt7kgotk71vbi7qhk",
+                    "id": "l2sw1_2",
+                    "name": "l2sw1_2",
+                    "type_connection": 0,
+                    "vlan": 10
+                },
+                {
+                    "connect": "edge_lsvt7lsaafcgf2zwbes",
+                    "id": "l2sw1_3",
+                    "name": "l2sw1_3",
+                    "type_connection": 0,
+                    "vlan": 20
+                }
+            ],
+            "position": {
+                "x": 151.25,
+                "y": 122
+            }
+        },
+        {
+            "classes": [
+                "l2_switch"
+            ],
+            "config": {
+                "label": "l2sw2",
+                "stp": 0,
+                "type": "l2_switch"
+            },
+            "data": {
+                "id": "l2sw2",
+                "label": "l2sw2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lsvt7j4wwvzphob3csn",
+                    "id": "l2sw2_1",
+                    "name": "l2sw2_1",
+                    "type_connection": 1,
+                    "vlan": [
+                        10,
+                        20
+                    ]
+                },
+                {
+                    "connect": "edge_lsvt7n3i7k1ecui2yb6",
+                    "id": "l2sw2_2",
+                    "name": "l2sw2_2",
+                    "type_connection": 0,
+                    "vlan": 10
+                },
+                {
+                    "connect": "edge_lsvt7odptverujybd1g",
+                    "id": "l2sw2_3",
+                    "name": "l2sw2_3",
+                    "type_connection": 0,
+                    "vlan": 20
+                }
+            ],
+            "position": {
+                "x": 273.25,
+                "y": 121.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lsvt7kgotk71vbi7qhk",
+                    "id": "iface_40853277",
+                    "ip": "10.0.0.1",
+                    "name": "iface_40853277",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 57.25,
+                "y": 50.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_3",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lsvt7lsaafcgf2zwbes",
+                    "id": "iface_81283760",
+                    "ip": "10.0.0.1",
+                    "name": "iface_81283760",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 66.2517058976607,
+                "y": 183.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_3",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lsvt7n3i7k1ecui2yb6",
+                    "id": "iface_78141057",
+                    "ip": "10.0.0.2",
+                    "name": "iface_78141057",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 339.75,
+                "y": 49
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "host_4",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_4",
+                "label": "host_4"
+            },
+            "interface": [
+                {
+                    "connect": "edge_lsvt7odptverujybd1g",
+                    "id": "iface_81333435",
+                    "ip": "10.0.0.2",
+                    "name": "iface_81333435",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 343.25,
+                "y": 188
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_lsvt7j4wwvzphob3csn",
+                "source": "l2sw1",
+                "target": "l2sw2",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lsvt7kgotk71vbi7qhk",
+                "source": "host_1",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lsvt7lsaafcgf2zwbes",
+                "source": "host_2",
+                "target": "l2sw1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lsvt7n3i7k1ecui2yb6",
+                "source": "host_3",
+                "target": "l2sw2",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_lsvt7odptverujybd1g",
+                "source": "host_4",
+                "target": "l2sw2",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "1556e30c34a442d199ac43be1a7c94ef",
+            "level": 0,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "10.0.0.2",
+            "print_cmd": "ping -c 1 10.0.0.2"
+        },
+        {
+            "id": "f6cf9aa95bb54dd48524395a5dbbdde8",
+            "level": 1,
+            "job_id": 1,
+            "host_id": "host_2",
+            "arg_1": "10.0.0.2",
+            "print_cmd": "ping -c 1 10.0.0.2"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 552.9815104166664,
+        "pan_y": 217.99166666666656
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/back/bench/examples/vxlan_network.json
+++ b/back/bench/examples/vxlan_network.json
@@ -1,0 +1,297 @@
+{
+    "nodes": [
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_1",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_1",
+                "label": "router_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_m1uftm3s5boohtmek6g",
+                    "id": "iface_16050474",
+                    "ip": "192.168.1.10",
+                    "name": "iface_16050474",
+                    "netmask": 24,
+                    "vxlan_connection_type": 0,
+                    "vxlan_vni": 2000,
+                    "vxlan_vni_to_target_ip": null
+                },
+                {
+                    "connect": "edge_m1uftnzz5b7wla9mt1c",
+                    "id": "iface_57688254",
+                    "ip": "10.0.0.1",
+                    "name": "iface_57688254",
+                    "netmask": 24,
+                    "vxlan_connection_type": 1,
+                    "vxlan_vni": null,
+                    "vxlan_vni_to_target_ip": [
+                        [
+                            "2000",
+                            "10.0.0.2"
+                        ],
+                        [
+                            "1000",
+                            "10.0.0.2"
+                        ]
+                    ]
+                },
+                {
+                    "connect": "edge_m1uftoz5xis4twfvt",
+                    "id": "iface_02067447",
+                    "ip": "192.168.1.100",
+                    "name": "iface_02067447",
+                    "netmask": 24,
+                    "vxlan_connection_type": 0,
+                    "vxlan_vni": 1000,
+                    "vxlan_vni_to_target_ip": null
+                }
+            ],
+            "position": {
+                "x": 143.99780670300765,
+                "y": 162.79711869966582
+            }
+        },
+        {
+            "classes": [
+                "l3_router"
+            ],
+            "config": {
+                "default_gw": "",
+                "label": "router_2",
+                "type": "router"
+            },
+            "data": {
+                "id": "router_2",
+                "label": "router_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_m1uftn3ez2s9vjq6dpc",
+                    "id": "iface_04670040",
+                    "ip": "192.168.1.20",
+                    "name": "iface_04670040",
+                    "netmask": 24,
+                    "vxlan_vni": 2000,
+                    "vxlan_connection_type": 0,
+                    "vxlan_vni_to_target_ip": null
+                },
+                {
+                    "connect": "edge_m1uftnzz5b7wla9mt1c",
+                    "id": "iface_13818414",
+                    "ip": "10.0.0.2",
+                    "name": "iface_13818414",
+                    "netmask": 24,
+                    "vxlan_vni": null,
+                    "vxlan_connection_type": 1,
+                    "vxlan_vni_to_target_ip": [
+                        [
+                            "2000",
+                            "10.0.0.1"
+                        ],
+                        [
+                            "1000",
+                            "10.0.0.1"
+                        ]
+                    ]
+                },
+                {
+                    "connect": "edge_m1uftpvcdz8gc2fpbew",
+                    "id": "iface_64175116",
+                    "ip": "192.168.1.200",
+                    "name": "iface_64175116",
+                    "netmask": 24,
+                    "vxlan_vni": 1000,
+                    "vxlan_connection_type": 0,
+                    "vxlan_vni_to_target_ip": null
+                }
+            ],
+            "position": {
+                "x": 258,
+                "y": 162.796875
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.100",
+                "label": "host_1",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_1",
+                "label": "host_1"
+            },
+            "interface": [
+                {
+                    "connect": "edge_m1uftoz5xis4twfvt",
+                    "id": "iface_14567101",
+                    "ip": "192.168.1.1",
+                    "name": "iface_14567101",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 45.5,
+                "y": 230.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.10",
+                "label": "host_2",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_2",
+                "label": "host_2"
+            },
+            "interface": [
+                {
+                    "connect": "edge_m1uftm3s5boohtmek6g",
+                    "id": "iface_04672555",
+                    "ip": "192.168.1.1",
+                    "name": "iface_04672555",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 48.5,
+                "y": 104.5
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.20",
+                "label": "host_3",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_3",
+                "label": "host_3"
+            },
+            "interface": [
+                {
+                    "connect": "edge_m1uftn3ez2s9vjq6dpc",
+                    "id": "iface_53522355",
+                    "ip": "192.168.1.2",
+                    "name": "iface_53522355",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 343,
+                "y": 102
+            }
+        },
+        {
+            "classes": [
+                "host"
+            ],
+            "config": {
+                "default_gw": "192.168.1.200",
+                "label": "host_4",
+                "type": "host"
+            },
+            "data": {
+                "id": "host_4",
+                "label": "host_4"
+            },
+            "interface": [
+                {
+                    "connect": "edge_m1uftpvcdz8gc2fpbew",
+                    "id": "iface_20347788",
+                    "ip": "192.168.1.2",
+                    "name": "iface_20347788",
+                    "netmask": 24
+                }
+            ],
+            "position": {
+                "x": 350,
+                "y": 233
+            }
+        }
+    ],
+    "edges": [
+        {
+            "data": {
+                "id": "edge_m1uftm3s5boohtmek6g",
+                "source": "router_1",
+                "target": "host_2",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_m1uftn3ez2s9vjq6dpc",
+                "source": "router_2",
+                "target": "host_3",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_m1uftnzz5b7wla9mt1c",
+                "source": "router_1",
+                "target": "router_2",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_m1uftoz5xis4twfvt",
+                "source": "router_1",
+                "target": "host_1",
+                "loss_percentage": 0
+            }
+        },
+        {
+            "data": {
+                "id": "edge_m1uftpvcdz8gc2fpbew",
+                "source": "router_2",
+                "target": "host_4",
+                "loss_percentage": 0
+            }
+        }
+    ],
+    "jobs": [
+        {
+            "id": "77debad276b04a1da7ee69f672163b27",
+            "level": 0,
+            "job_id": 1,
+            "host_id": "host_1",
+            "arg_1": "192.168.1.2",
+            "print_cmd": "ping -c 1 192.168.1.2"
+        },
+        {
+            "id": "8bed6a2c6a5c4c74b7aba66cf602533e",
+            "level": 1,
+            "job_id": 1,
+            "host_id": "host_2",
+            "arg_1": "192.168.1.2",
+            "print_cmd": "ping -c 1 192.168.1.2"
+        }
+    ],
+    "config": {
+        "zoom": 2.0,
+        "pan_x": 264.0848965405208,
+        "pan_y": 47.02682620003628
+    },
+    "packets": "",
+    "pcap": []
+}

--- a/scripts/bench-emulation.sh
+++ b/scripts/bench-emulation.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# bench-emulation.sh — run the Miminet emulation benchmark locally.
+#
+# Runs back/bench/bench.py inside the same isolated container used by
+# back-test.sh (repo mounted read-only, emulation in the container's own
+# network namespace). Writes a JSON report with per-network phase timings,
+# peak RSS and ovs-vswitchd RSS deltas.
+#
+# Usage:
+#   bench-emulation.sh [--build] [--networks <dir|files>] [--repeats N]
+#                      [--out <path>] [--quiet] [--env KEY=VALUE]...
+#
+# Examples:
+#   scripts/bench-emulation.sh --build --repeats 1 --out .bench/report.json
+#   scripts/bench-emulation.sh --networks back/tests/test_json --repeats 3
+#   scripts/bench-emulation.sh --networks \
+#       back/tests/test_json/rstp_four_switch_network.json,back/tests/test_json/vlan_with_vxlan_network.json
+#   scripts/bench-emulation.sh --networks back/bench/examples \
+#       --env MIMINET_SETTLE_MIN=1.0
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/lib-back-env.sh"
+
+REPO_ROOT="$BACK_REPO_ROOT"
+BUILD=0
+NETWORKS="$REPO_ROOT/back/tests/test_json"
+REPEATS=1
+OUT="$REPO_ROOT/.bench/report.json"
+QUIET=""
+ENVS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build) BUILD=1; shift ;;
+        --networks) NETWORKS="$2"; shift 2 ;;
+        --repeats) REPEATS="$2"; shift 2 ;;
+        --out) OUT="$2"; shift 2 ;;
+        --quiet) QUIET="--quiet"; shift ;;
+        --env) ENVS+=("$2"); shift 2 ;;
+        *) echo "unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+detect_engine
+
+if [[ "$BUILD" == "1" ]]; then
+    "$BACK_ENGINE" build -t "$BACK_IMAGE" -f "$REPO_ROOT/back/Dockerfile" "$REPO_ROOT"
+fi
+
+# The report must land on a writable mount; the repo is mounted read-only, so
+# bind-mount the report's directory read-write on top of it.
+OUT_DIR="$(dirname "$OUT")"
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+OUT_FILE="$(basename "$OUT")"
+REPORT_PATH_IN_CT="/repo/.bench/$OUT_FILE"
+
+# Translate repo-root host paths into the container's /repo layout.
+NETWORKS_CT="${NETWORKS/#$REPO_ROOT/\/repo}"
+
+echo "[bench] engine=$BACK_ENGINE image=$BACK_IMAGE"
+echo "[bench] networks=$NETWORKS_CT repeats=$REPEATS out=$OUT"
+
+ENV_EXPORTS=""
+for kv in "${ENVS[@]}"; do
+    ENV_EXPORTS+="export $kv; "
+done
+
+"$BACK_ENGINE" run $(base_run_args) $(engine_flags) \
+    -v "$OUT_DIR":/repo/.bench \
+    "$BACK_IMAGE" \
+    -c "
+        set -e
+        ${ENV_EXPORTS}bash /repo/back/ovs-init.sh
+        PYTHONPATH=/repo/back/src /app/.venv/bin/python /repo/back/bench/bench.py \
+            --networks \"$NETWORKS_CT\" --repeats \"$REPEATS\" --out \"$REPORT_PATH_IN_CT\" $QUIET
+        mn -c >/dev/null 2>&1 || true
+    "
+
+echo "[bench] report: $OUT"

--- a/scripts/fetch-example-networks.py
+++ b/scripts/fetch-example-networks.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Fetch the public example networks from miminet.ru into back/bench/examples/.
+
+The "/examples" page networks are stored only in the deployed PostgreSQL
+database, but each one is served to anonymous visitors at
+``/web_network_shared?guid=<guid>`` with the full network definition embedded
+in the page as ``var nodes``, ``const edges`` and ``var jobs`` JS literals
+(plus ``network_zoom`` / ``network_pan_x`` / ``network_pan_y``).
+
+This script reconstructs the canonical benchmark JSON
+(``{nodes, edges, jobs, config, packets:"", pcap:[]}``) for each example and
+writes it to ``back/bench/examples/<slug>_network.json`` so the benchmark
+harness can consume it unchanged (``bench.py --networks <dir>`` globs
+``*_network.json``).
+
+Usage:
+    python3 scripts/fetch-example-networks.py [--out DIR]
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+BASE_URL = "https://miminet.ru/web_network_shared"
+
+# (guid, slug) as listed on the public /examples page.
+EXAMPLES = [
+    ("d5eb566d-402e-442f-a98a-d5341568a5c9", "switch_and_hub"),
+    ("385ccc51-9a6e-4b9a-8e90-fbf27ae73186", "router"),
+    ("19e7c6b6-9541-4602-8c78-d0c64c069b41", "nat_2"),
+    ("7509b963-d190-4aad-8d90-9be42f302bbb", "ring_of_3_routers"),
+    ("076f1ae4-1a6d-42fd-b8f5-9c09cdc4f930", "first_and_last_ip_address"),
+    ("d35bcad2-b2be-4c2a-9902-26d4edd0bb1d", "tcp_connection_setup_1"),
+    ("6994b921-cc0f-4cbd-b209-7f30784027d7", "icmp_network_unavailable"),
+    ("1646e111-1a47-4d98-a253-c396904e5351", "icmp_host_unreachable"),
+    ("4fc0fafb-2a16-4244-a664-3f1e8f788a63", "multicast_udp"),
+    ("0a1be702-d7fb-4e97-a8ae-fe9cb75fcf32", "stp"),
+    ("1ccd87d4-a74f-485e-a95e-e1111c041fc7", "vlan"),
+    ("fe1fc02f-6bb4-421d-94cb-6902f826e30d", "ipip_tunnel"),
+    ("993e2d62-ae6c-4b62-9ec4-6d90f768b56a", "vxlan"),
+]
+
+
+def fetch_page(guid: str) -> str:
+    url = f"{BASE_URL}?guid={guid}"
+    req = urllib.request.Request(url, headers={"User-Agent": "miminet-bench"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        if resp.url != url:
+            raise RuntimeError(f"redirected to {resp.url} (not share_mode?)")
+        return resp.read().decode("utf-8")
+
+
+def extract_var(html: str, varname: str, kind: str):
+    """Capture a JS variable body from the page and parse it."""
+    pattern = rf"(?:const|var)\s+{varname}\s*=\s*(.*?);\s*\n"
+    m = re.search(pattern, html, re.DOTALL)
+    if not m:
+        raise RuntimeError(f"variable '{varname}' not found")
+    text = m.group(1).strip()
+    if kind == "json":
+        return json.loads(text)
+    if kind == "literal":
+        return ast.literal_eval(text)
+    return text
+
+
+def build_network_json(html: str) -> dict:
+    nodes = extract_var(html, "nodes", "json")
+    edges = extract_var(html, "edges", "literal")
+    jobs = extract_var(html, "jobs", "literal")
+    zoom = extract_var(html, "network_zoom", "scalar")
+    pan_x = extract_var(html, "network_pan_x", "scalar")
+    pan_y = extract_var(html, "network_pan_y", "scalar")
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "jobs": jobs,
+        "config": {"zoom": float(zoom), "pan_x": float(pan_x), "pan_y": float(pan_y)},
+        "packets": "",
+        "pcap": [],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        default=str(Path(__file__).resolve().parent.parent / "back" / "bench" / "examples"),
+        help="output directory for *_network.json files",
+    )
+    args = parser.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    ok = 0
+    for guid, slug in EXAMPLES:
+        out_path = out_dir / f"{slug}_network.json"
+        try:
+            html = fetch_page(guid)
+            net = build_network_json(html)
+        except Exception as e:  # noqa: BLE001
+            print(f"[fetch] {slug:<24} FAILED: {e!r}", flush=True)
+            continue
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(net, fh, ensure_ascii=False, indent=4)
+        print(
+            f"[fetch] {slug:<24} nodes={len(net['nodes']):<3} "
+            f"edges={len(net['edges']):<3} jobs={len(net['jobs']):<2} -> {out_path}",
+            flush=True,
+        )
+        ok += 1
+
+    print(f"[fetch] wrote {ok}/{len(EXAMPLES)} examples to {out_dir}", flush=True)
+    sys.exit(0 if ok == len(EXAMPLES) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib-back-env.sh
+++ b/scripts/lib-back-env.sh
@@ -11,6 +11,12 @@ set -euo pipefail
 BACK_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 detect_engine() {
+    if [[ -n "${BACK_ENGINE:-}" ]]; then
+        if command -v "$BACK_ENGINE" >/dev/null 2>&1; then
+            return 0
+        fi
+        echo "[warn] BACK_ENGINE=$BACK_ENGINE not found; auto-detecting" >&2
+    fi
     if command -v docker >/dev/null 2>&1; then
         if docker info >/dev/null 2>&1; then
             BACK_ENGINE="docker"


### PR DESCRIPTION
Upstreams the emulation benchmark harness from wip/bench-emulation (benchmark + extraction only):
- back/bench/bench.py + 12 public example networks
- scripts/bench-emulation.sh, scripts/fetch-example-networks.py
- BACK_ENGINE override in scripts/lib-back-env.sh
Every API bench.py calls exists on main; job ordering mirrors emulator.py.