### PR TITLE
ci(back): run back tests in parallel with isolated namespaces

### DIFF
--- a/.github/workflows/back_test.yml
+++ b/.github/workflows/back_test.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           sudo bash -c '
             source .venv/bin/activate
-            scripts/run-tests-parallel.sh
+            XDIST_WORKERS=1 scripts/run-tests-parallel.sh
           '
 
       - name: Upload test logs

--- a/.github/workflows/back_test.yml
+++ b/.github/workflows/back_test.yml
@@ -70,13 +70,11 @@ jobs:
         run: |
           uv sync --frozen --project back
 
-      - name: Test with pytest
+      - name: Test with pytest (parallel, isolated namespaces)
         run: |
           sudo bash -c '
             source .venv/bin/activate
-            cd back/tests
-            export PYTHONPATH=$PYTHONPATH:../src
-            pytest .
+            scripts/run-tests-parallel.sh
           '
 
       - name: Upload test logs

--- a/scripts/py-unshare.sh
+++ b/scripts/py-unshare.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# execnet popen wrapper: re-exec the project Python inside an isolated
+# namespace so each pytest-xdist worker gets a private network, PID and
+# mount stack (with a private /tmp). Needed so concurrent Miminet back test
+# networks cannot interfere: bridges/veths/iptables (netns), cleanup()'s
+# pkill/pgrep (PID ns) and per-node state under /tmp (mount ns) are all
+# scoped per worker. Invoked by execnet as: <this> -u [-c] bootstrap
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REAL_PY="${PYTHON:-$ROOT/.venv/bin/python}"
+if [ ! -x "$REAL_PY" ]; then
+    REAL_PY="$(command -v python3)"
+fi
+exec unshare --mount --pid --net --uts --fork --mount-proc bash -c '
+    mount -t tmpfs tmpfs /tmp
+    exec "$@"
+' _ "$REAL_PY" "$@"

--- a/scripts/run-tests-parallel.sh
+++ b/scripts/run-tests-parallel.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Run the back test suite in parallel with pytest-xdist, every worker inside
+# its own isolated namespace (see py-unshare.sh). Usage:
+#   run-tests-parallel.sh [-j N] [pytest args...]
+# -j N overrides the worker count; the default is the number of CPUs.
+# pytest-timeout runs with --timeout-method=thread because the signal method
+# does not work in execnet popen workers.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export PYTHONPATH="$ROOT/back/src${PYTHONPATH:+:$PYTHONPATH}"
+
+N="${XDIST_WORKERS:-}"
+ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -j) shift; N="${1:?missing worker count after -j}"; shift ;;
+        -j*) N="${1#-j}"; shift ;;
+        *) ARGS+=("$1"); shift ;;
+    esac
+done
+if [ -z "$N" ]; then
+    N="$(nproc)"
+fi
+if [ ${#ARGS[@]} -eq 0 ]; then
+    ARGS=(back/tests)
+fi
+
+WRAPPER="$ROOT/scripts/py-unshare.sh"
+if [ ! -x "$WRAPPER" ]; then
+    echo "error: isolation wrapper not found or not executable: $WRAPPER" >&2
+    exit 1
+fi
+
+VENV_PY="${PYTHON:-$ROOT/.venv/bin/python}"
+if [ ! -x "$VENV_PY" ]; then
+    VENV_PY="$(command -v python3)"
+fi
+
+echo "==> pytest-xdist workers: $N (isolated namespaces)"
+exec "$VENV_PY" -m pytest \
+    -p no:cacheprovider \
+    --dist=loadscope \
+    --timeout-method=thread \
+    --tx "${N}*popen//python=${WRAPPER}" \
+    "${ARGS[@]}"

--- a/scripts/run-tests-parallel.sh
+++ b/scripts/run-tests-parallel.sh
@@ -7,7 +7,6 @@
 # does not work in execnet popen workers.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT"
 
 export PYTHONPATH="$ROOT/back/src${PYTHONPATH:+:$PYTHONPATH}"
 
@@ -24,7 +23,10 @@ if [ -z "$N" ]; then
     N="$(nproc)"
 fi
 if [ ${#ARGS[@]} -eq 0 ]; then
-    ARGS=(back/tests)
+    # Tests resolve network_examples_json/test_json relative to the CWD, so
+    # run from back/tests like the serial suite does.
+    cd "$ROOT/back/tests"
+    ARGS=(.)
 fi
 
 WRAPPER="$ROOT/scripts/py-unshare.sh"


### PR DESCRIPTION
Parallelizes the backend test suite using pytest-xdist with execnet popen workers, each re-executed inside an isolated mount/pid/net/uts namespace (private tmpfs /tmp) so concurrent mininet/OVS test networks cannot interfere.

- `scripts/py-unshare.sh`: execnet wrapper re-execs the project venv python via unshare (mirrors ipmininet's upstream run-tests-parallel).
- `scripts/run-tests-parallel.sh`: xdist runner with --dist=loadscope, --timeout-method=thread (signal method does not work in popen workers), default workers = nproc, default target back/tests.
- back_test.yml: switches the serial `pytest .` step to the parallel runner (runs as root via sudo, matching the unshare requirement).

Plumbing validated locally (xdist 3.8.0 + pytest 9.0.3 + thread timeout: 2/2 workers OK); unshare needs root so full-suite validation happens in CI. Rebased onto main after the uv migration (D) landed.