### PR TITLE
ci: switch linter to ruff (check + format), keep mypy

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,10 +38,10 @@ jobs:
         run: |
           uv run --frozen mypy --ignore-missing-imports ${{matrix.node}}
 
-      - name: Format with black
+      - name: Format with ruff
         run: |
-          uv run --frozen black --check --verbose --diff ${{matrix.node}}
+          uv run --frozen ruff format --check --verbose ${{matrix.node}}
 
-      - name: Lint with flake8
+      - name: Lint with ruff
         run: |
-          uv run --frozen flake8 --count --verbose --max-line-length=88 --extend-ignore=E501,W391,C901,E203 --statistics ${{matrix.node}}
+          uv run --frozen ruff check --verbose ${{matrix.node}}

--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -18,8 +18,6 @@ dev = [
     "pytest",
     "pytest-timeout==2.4.0",
     "pytest-xdist",
-    "black~=26.3",
-    "flake8",
     "isort",
     "mypy",
     "types-requests",

--- a/back/src/net_utils/vlan.py
+++ b/back/src/net_utils/vlan.py
@@ -38,20 +38,20 @@ def clean_bridges(net: IPNet) -> None:
     """
 
     for switch in net.switches:
-        switch.cmd(f'ip link set {f"br-{switch.name}"} down')
+        switch.cmd(f"ip link set {f'br-{switch.name}'} down")
         if isinstance(switch, IPOVSSwitch):
-            switch.vsctl(f' del-br {f"br-{switch.name}"}')
+            switch.vsctl(f" del-br {f'br-{switch.name}'}")
         else:
-            switch.cmd(f'brctl delbr {f"br-{switch.name}"}')
+            switch.cmd(f"brctl delbr {f'br-{switch.name}'}")
 
 
 def configure_access(switch: IPSwitch, intf: str, vlan: int) -> None:
     if isinstance(switch, IPOVSSwitch):
         switch.vsctl(f" del-port {switch} {intf}")
-        switch.vsctl(f' add-port {f"br-{switch.name}"} {intf}')
+        switch.vsctl(f" add-port {f'br-{switch.name}'} {intf}")
         switch.vsctl(f" set port {intf} tag={vlan}")
     else:
-        switch.cmd(f'ip link set {intf} master {f"br-{switch.name}"}')
+        switch.cmd(f"ip link set {intf} master {f'br-{switch.name}'}")
         switch.cmd(f"bridge vlan del dev {intf} vid 1")
         switch.cmd(f"bridge vlan add dev {intf} vid {vlan} pvid untagged")
 
@@ -59,10 +59,10 @@ def configure_access(switch: IPSwitch, intf: str, vlan: int) -> None:
 def configure_trunk(switch: IPSwitch, intf: str, vlans: list[int]) -> None:
     if isinstance(switch, IPOVSSwitch):
         switch.vsctl(f" del-port {switch} {intf}")
-        switch.vsctl(f' add-port {f"br-{switch.name}"} {intf}')
+        switch.vsctl(f" add-port {f'br-{switch.name}'} {intf}")
         switch.vsctl(f" set port {intf} trunks={','.join(map(str, vlans))}")
     else:
-        switch.cmd(f'ip link set {intf} master {f"br-{switch.name}"}')
+        switch.cmd(f"ip link set {intf} master {f'br-{switch.name}'}")
         switch.cmd(f"bridge vlan del dev {intf} vid 1")
 
         for vlan in vlans:
@@ -77,11 +77,11 @@ def has_vlan_interfaces(interfaces: list[NodeInterface]) -> bool:
 def add_bridge(switch: IPSwitch, interface: list[NodeInterface]) -> None:
     if isinstance(switch, IPOVSSwitch):
         if has_vlan_interfaces(interface):
-            switch.vsctl(f' add-br {f"br-{switch.name}"}')
+            switch.vsctl(f" add-br {f'br-{switch.name}'}")
             switch.vsctl(
-                f' set bridge {f"br-{switch.name}"} other_config:enable-vlan-filtering=true'
+                f" set bridge {f'br-{switch.name}'} other_config:enable-vlan-filtering=true"
             )
     else:
-        switch.cmd(f'ip link add name {f"br-{switch.name}"} type bridge')
-    switch.cmd(f'ip link set dev {f"br-{switch.name}"} up')
-    switch.cmd(f'ip link set dev {f"br-{switch.name}"} type bridge vlan_filtering 1')
+        switch.cmd(f"ip link add name {f'br-{switch.name}'} type bridge")
+    switch.cmd(f"ip link set dev {f'br-{switch.name}'} up")
+    switch.cmd(f"ip link set dev {f'br-{switch.name}'} type bridge vlan_filtering 1")

--- a/back/tests/test_duplication.py
+++ b/back/tests/test_duplication.py
@@ -31,9 +31,9 @@ def assert_duplicate_and_loss_present(animation_json: str) -> None:
     for group in animation:
         for pkt in group:
             cfg = pkt.get("config", {})
-            assert (
-                "duplicate_percentage" in cfg
-            ), "duplicate_percentage missing in packet config"
+            assert "duplicate_percentage" in cfg, (
+                "duplicate_percentage missing in packet config"
+            )
             assert "loss_percentage" in cfg, "loss_percentage missing in packet config"
 
 
@@ -50,9 +50,9 @@ def test_duplicate_edges_double_packets():
     count_with_dup = count_packets(animation_with_dup)
     count_no_dup = count_packets(animation_no_dup)
 
-    assert (
-        count_with_dup > count_no_dup
-    ), f"Packets with duplication ({count_with_dup}) should be greater than packets without duplication ({count_no_dup})"
+    assert count_with_dup > count_no_dup, (
+        f"Packets with duplication ({count_with_dup}) should be greater than packets without duplication ({count_no_dup})"
+    )
 
 
 def test_backward_compatibility_no_dup_percentage():

--- a/back/tests/test_network_ready.py
+++ b/back/tests/test_network_ready.py
@@ -219,9 +219,11 @@ def test_restart_captures_kills_removes_restarts():
     }
     net = make_net(interfaces, intfs)
 
-    with mock.patch("src.network.os.path.exists", return_value=True), mock.patch(
-        "src.network.os.remove"
-    ) as remove_mock, mock.patch("src.network.info"):
+    with (
+        mock.patch("src.network.os.path.exists", return_value=True),
+        mock.patch("src.network.os.remove") as remove_mock,
+        mock.patch("src.network.info"),
+    ):
         restart_captures(net, [("host1", "l1a")])
 
     assert proc.killed
@@ -242,9 +244,11 @@ def test_restart_captures_skips_unknown_endpoints():
     }
     net = make_net(interfaces, intfs)
 
-    with mock.patch("src.network.os.path.exists", return_value=True), mock.patch(
-        "src.network.os.remove"
-    ) as remove_mock, mock.patch("src.network.info"):
+    with (
+        mock.patch("src.network.os.path.exists", return_value=True),
+        mock.patch("src.network.os.remove") as remove_mock,
+        mock.patch("src.network.info"),
+    ):
         restart_captures(net, [("ghost", "nope")])
 
     assert not capture.started
@@ -256,19 +260,22 @@ def test_restart_captures_skips_unknown_endpoints():
 
 def test_wait_until_ready_all_live_returns():
     net = MiminetNetwork.__new__(MiminetNetwork)
-    with mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=[]
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
-    ), mock.patch(
-        "src.network.time.monotonic", return_value=0.0
-    ), mock.patch(
-        "src.network.time.sleep"
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__restart_captures"
-    ) as restart:
+    with (
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=[]
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
+        ),
+        mock.patch("src.network.time.monotonic", return_value=0.0),
+        mock.patch("src.network.time.sleep"),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__restart_captures"
+        ) as restart,
+    ):
         wait_until_ready(net)
 
     restart.assert_not_called()
@@ -277,19 +284,22 @@ def test_wait_until_ready_all_live_returns():
 def test_wait_until_ready_timeout_lists_captures():
     net = MiminetNetwork.__new__(MiminetNetwork)
     not_live = [("host1", "l1a"), ("router1", "l1b")]
-    with mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=not_live
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
-    ), mock.patch(
-        "src.network.time.monotonic", side_effect=monotonic_clock()
-    ), mock.patch(
-        "src.network.time.sleep"
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__restart_captures"
-    ) as restart:
+    with (
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=not_live
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
+        ),
+        mock.patch("src.network.time.monotonic", side_effect=monotonic_clock()),
+        mock.patch("src.network.time.sleep"),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__restart_captures"
+        ) as restart,
+    ):
         with pytest.raises(TimeoutError) as excinfo:
             wait_until_ready(net)
 
@@ -300,21 +310,25 @@ def test_wait_until_ready_timeout_lists_captures():
 def test_wait_until_ready_restarts_once_after_grace():
     net = MiminetNetwork.__new__(MiminetNetwork)
     not_live = [("host1", "l1a")]
-    with mock.patch.dict(
-        "src.network.os.environ", {"MIMINET_CAPTURE_RESTART_GRACE": "0.0"}
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=not_live
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
-    ), mock.patch(
-        "src.network.time.monotonic", side_effect=monotonic_clock()
-    ), mock.patch(
-        "src.network.time.sleep"
-    ), mock.patch.object(
-        MiminetNetwork, "_MiminetNetwork__restart_captures"
-    ) as restart:
+    with (
+        mock.patch.dict(
+            "src.network.os.environ", {"MIMINET_CAPTURE_RESTART_GRACE": "0.0"}
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__captures_not_live", return_value=not_live
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__unconverged_switches", return_value=[]
+        ),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__unreachable_vtep_targets", return_value=[]
+        ),
+        mock.patch("src.network.time.monotonic", side_effect=monotonic_clock()),
+        mock.patch("src.network.time.sleep"),
+        mock.patch.object(
+            MiminetNetwork, "_MiminetNetwork__restart_captures"
+        ) as restart,
+    ):
         with pytest.raises(TimeoutError):
             wait_until_ready(net)
 

--- a/front/pyproject.toml
+++ b/front/pyproject.toml
@@ -36,8 +36,6 @@ dev = [
     "pytest-mock==3.15.1",
     "pytest-timeout==2.4.0",
     "selenium",
-    "black~=26.3",
-    "flake8",
     "isort",
     "mypy",
     "types-requests",

--- a/front/src/auth_tests/yandex_test.py
+++ b/front/src/auth_tests/yandex_test.py
@@ -141,9 +141,7 @@ def test_yandex_callback_links_yandex_to_current_profile(app, mocker):
         mock_user = mocker.patch("miminet_auth.User")
         mock_user.query.get.return_value = linked_user
         mock_user.query.filter_by.return_value.first.return_value = None
-        mock_oauth2session.return_value.get.return_value.raise_for_status.return_value = (
-            None
-        )
+        mock_oauth2session.return_value.get.return_value.raise_for_status.return_value = None
         mock_oauth2session.return_value.get.return_value.json.return_value = {
             "id": "test_id",
             "login": "test_login",
@@ -234,9 +232,7 @@ def test_yandex_callback_redirects_to_home_after_login(app, mocker):
         mock_oauth2session = mocker.patch("miminet_auth.OAuth2Session")
         mock_user = mocker.patch("miminet_auth.User")
         mock_login_user = mocker.patch("miminet_auth.login_user")
-        mock_oauth2session.return_value.get.return_value.raise_for_status.return_value = (
-            None
-        )
+        mock_oauth2session.return_value.get.return_value.raise_for_status.return_value = None
         mock_oauth2session.return_value.get.return_value.json.return_value = {
             "id": "test_id",
             "login": "test_login",
@@ -273,9 +269,7 @@ def test_yandex_callback_handles_user_not_added_to_db_error(app, mocker):
         mock_session = mocker.patch("miminet_auth.db.session")
         mock_flash = mocker.patch("miminet_auth.flash")
         mock_logger = mocker.patch("miminet_auth.logger.error")
-        mock_oauth2session.return_value.get.return_value.raise_for_status.return_value = (
-            None
-        )
+        mock_oauth2session.return_value.get.return_value.raise_for_status.return_value = None
         mock_oauth2session.return_value.get.return_value.json.return_value = {
             "id": "test_id",
             "login": "test_login",

--- a/front/tests/conftest.py
+++ b/front/tests/conftest.py
@@ -304,9 +304,9 @@ def requester():
 
     response = session.get(MAIN_PAGE)
 
-    assert (
-        response.status_code == 200
-    ), "Miminet is not running or its address is incorrect: unable to get home page!"
+    assert response.status_code == 200, (
+        "Miminet is not running or its address is incorrect: unable to get home page!"
+    )
 
     response = session.post(
         f"{MAIN_PAGE}//auth/login.html",

--- a/front/tests/test_basic.py
+++ b/front/tests/test_basic.py
@@ -4,7 +4,6 @@ from requests import Session
 
 
 class TestAvailability:
-
     def test_auth(self, selenium: MiminetTester):
         """Checks if it possible to open home page (are we authorized or not)"""
         selenium.get(HOME_PAGE)

--- a/front/tests/test_device_configure_names.py
+++ b/front/tests/test_device_configure_names.py
@@ -39,9 +39,9 @@ class TestDeviceNameChange:
 
             updated_node = network.nodes[node_id]
 
-            assert (
-                updated_node["config"]["label"] == new_device_name
-            ), "Failed to change device name."
+            assert updated_node["config"]["label"] == new_device_name, (
+                "Failed to change device name."
+            )
 
     def test_device_name_change_to_long(
         self, selenium: MiminetTester, network: MiminetTestNetwork
@@ -60,6 +60,6 @@ class TestDeviceNameChange:
             updated_node = network.nodes[node_id]
 
             # check that the name was cut off
-            assert (
-                updated_node["config"]["label"] != new_device_name
-            ), "The device name isn't limited in size."
+            assert updated_node["config"]["label"] != new_device_name, (
+                "The device name isn't limited in size."
+            )

--- a/front/tests/test_dhcp.py
+++ b/front/tests/test_dhcp.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeType
 
 
 class TestDHCP:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/test_down_link.py
+++ b/front/tests/test_down_link.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeType
 
 
 class TestLinkDown:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/test_fields_filter.py
+++ b/front/tests/test_fields_filter.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeType
 
 
 class TestFieldsFilter:
-
     @pytest.fixture(scope="function")
     def network(self, selenium: MiminetTester):
         # make simple network
@@ -35,9 +34,9 @@ class TestFieldsFilter:
         gw_input.send_keys("192,168ю1ю1")
 
         actual_value = gw_input.get_attribute("value")
-        assert (
-            actual_value == "192.168.1.1"
-        ), f"The filter failed. Expected '192.168.1.1', received '{actual_value}'"
+        assert actual_value == "192.168.1.1", (
+            f"The filter failed. Expected '192.168.1.1', received '{actual_value}'"
+        )
 
     def test_host_add_route_gateway_filter(
         self, selenium: MiminetTester, network: MiminetTestNetwork
@@ -62,9 +61,9 @@ class TestFieldsFilter:
         gw_element.clear()
         gw_element.send_keys("10,10ю10ю1")
 
-        assert (
-            gw_element.get_attribute("value") == "10.10.10.1"
-        ), "The gateway field filter did not work"
+        assert gw_element.get_attribute("value") == "10.10.10.1", (
+            "The gateway field filter did not work"
+        )
 
     def test_router_cidr_notation_add_ip(
         self, selenium: MiminetTester, network: MiminetTestNetwork

--- a/front/tests/test_job_edit.py
+++ b/front/tests/test_job_edit.py
@@ -61,15 +61,15 @@ class TestJobEdit:
 
         # Verify job was updated, not duplicated
         final_jobs_count = len(network.jobs)
-        assert (
-            final_jobs_count == 1
-        ), f"Job should be updated, not duplicated. Got {final_jobs_count} jobs"
+        assert final_jobs_count == 1, (
+            f"Job should be updated, not duplicated. Got {final_jobs_count} jobs"
+        )
 
         # Verify the new value is saved
         updated_job = network.jobs[0]
-        assert (
-            updated_job["arg_1"] == "192.168.1.100"
-        ), f"Job should have new IP, got: {updated_job['arg_1']}"
+        assert updated_job["arg_1"] == "192.168.1.100", (
+            f"Job should have new IP, got: {updated_job['arg_1']}"
+        )
 
         network.delete()
 
@@ -132,15 +132,15 @@ class TestJobEdit:
         config1.submit()
 
         # Verify still 30 jobs
-        assert (
-            len(network.jobs) == 30
-        ), f"Should still have 30 jobs after edit, got {len(network.jobs)}"
+        assert len(network.jobs) == 30, (
+            f"Should still have 30 jobs after edit, got {len(network.jobs)}"
+        )
 
         # Verify at least one job has the new IP (jobs may be reordered)
         job_ips = [job["arg_1"] for job in network.jobs]
-        assert (
-            "192.168.5.99" in job_ips
-        ), f"Updated IP should be in jobs list: {job_ips}"
+        assert "192.168.5.99" in job_ips, (
+            f"Updated IP should be in jobs list: {job_ips}"
+        )
         assert (
             first_job_original_ip not in job_ips
             or job_ips.count(first_job_original_ip) < 30
@@ -172,7 +172,7 @@ class TestJobEdit:
             config_host.add_jobs(
                 1,
                 {
-                    Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector: f"10.20.30.{10+i}"
+                    Location.Network.ConfigPanel.Host.Job.PING_FIELD.selector: f"10.20.30.{10 + i}"
                 },
             )
         config_host.submit()
@@ -220,11 +220,11 @@ class TestJobEdit:
 
         # Verify new IPs are present
         updated_ips = [job["arg_1"] for job in network.jobs]
-        assert (
-            "10.20.30.100" in updated_ips
-        ), f"First edited IP not found in {updated_ips}"
-        assert (
-            "10.20.30.101" in updated_ips
-        ), f"Second edited IP not found in {updated_ips}"
+        assert "10.20.30.100" in updated_ips, (
+            f"First edited IP not found in {updated_ips}"
+        )
+        assert "10.20.30.101" in updated_ips, (
+            f"Second edited IP not found in {updated_ips}"
+        )
 
         network.delete()

--- a/front/tests/test_job_limit.py
+++ b/front/tests/test_job_limit.py
@@ -51,9 +51,9 @@ class TestJobLimit:
             # Check error message quality
             assert "лимит" in error_message.lower(), "Error should mention limit"
             assert "30" in error_message, "Error should mention the limit number (30)"
-            assert (
-                "команд" in error_message.lower()
-            ), "Error should mention 'команд' (commands)"
+            assert "команд" in error_message.lower(), (
+                "Error should mention 'команд' (commands)"
+            )
 
         network.delete()
 
@@ -112,9 +112,9 @@ class TestJobLimit:
             )
         config_host2.submit()
 
-        assert (
-            len(network.jobs) == 30
-        ), f"Expected 30 jobs across all devices, but got {len(network.jobs)}"
+        assert len(network.jobs) == 30, (
+            f"Expected 30 jobs across all devices, but got {len(network.jobs)}"
+        )
 
         # Try to add 31st job to any device - should fail
         config_host2 = network.open_node_config(host2_id)
@@ -158,9 +158,9 @@ class TestJobLimit:
             )
         config1.submit()
 
-        assert (
-            len(network.jobs) == 30
-        ), f"Expected 30 jobs initially, but got {len(network.jobs)}"
+        assert len(network.jobs) == 30, (
+            f"Expected 30 jobs initially, but got {len(network.jobs)}"
+        )
 
         # Delete one job via API
         job_id_to_delete = network.jobs[0]["id"]
@@ -190,9 +190,9 @@ class TestJobLimit:
             }});
         """)
         assert delete_result["success"], "Failed to delete job"
-        assert (
-            len(network.jobs) == 29
-        ), f"Expected 29 jobs after deletion, but got {len(network.jobs)}"
+        assert len(network.jobs) == 29, (
+            f"Expected 29 jobs after deletion, but got {len(network.jobs)}"
+        )
 
         # Add a new job - should succeed
         config1 = network.open_node_config(host1_id)
@@ -202,8 +202,8 @@ class TestJobLimit:
         )
         config1.submit()
 
-        assert (
-            len(network.jobs) == 30
-        ), f"Expected 30 jobs after adding new one, but got {len(network.jobs)}"
+        assert len(network.jobs) == 30, (
+            f"Expected 30 jobs after adding new one, but got {len(network.jobs)}"
+        )
 
         network.delete()

--- a/front/tests/test_nat.py
+++ b/front/tests/test_nat.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeConfig, NodeType
 
 
 class TestNat:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/test_packet_filters.py
+++ b/front/tests/test_packet_filters.py
@@ -148,9 +148,9 @@ class TestPacketFilters:
         assert filtered_packets[0][0]["data"]["label"] == "ICMP packet"
 
         self._open_settings_modal(selenium)
-        assert (
-            self._checkbox_state(selenium, "ARPFilterCheckbox") is True
-        ), "ARP checkbox should remain selected after saving"
+        assert self._checkbox_state(selenium, "ARPFilterCheckbox") is True, (
+            "ARP checkbox should remain selected after saving"
+        )
         self._close_options_modal(selenium)
 
     def test_cancel_does_not_change_filter_state(
@@ -171,14 +171,14 @@ class TestPacketFilters:
         current_state = selenium.execute_script(
             "return packetFilterState.hideARP === true;"
         )
-        assert (
-            current_state == initial_state
-        ), "Filter state must not change when closing without saving"
+        assert current_state == initial_state, (
+            "Filter state must not change when closing without saving"
+        )
 
         self._open_settings_modal(selenium)
-        assert (
-            self._checkbox_state(selenium, "ARPFilterCheckbox") == initial_state
-        ), "ARP checkbox should display the original value after cancel"
+        assert self._checkbox_state(selenium, "ARPFilterCheckbox") == initial_state, (
+            "ARP checkbox should display the original value after cancel"
+        )
         self._close_options_modal(selenium)
 
     def test_enable_stp_filter_filters_packets(
@@ -218,9 +218,9 @@ class TestPacketFilters:
         assert filtered_packets[0][0]["data"]["label"] == "ICMP packet"
 
         self._open_settings_modal(selenium)
-        assert (
-            self._checkbox_state(selenium, "STPFilterCheckbox") is True
-        ), "STP checkbox should remain selected after saving"
+        assert self._checkbox_state(selenium, "STPFilterCheckbox") is True, (
+            "STP checkbox should remain selected after saving"
+        )
         self._close_options_modal(selenium)
 
     def test_enable_syn_filter_filters_packets(
@@ -262,9 +262,9 @@ class TestPacketFilters:
         assert filtered_packets[0][0]["data"]["label"] == "TCP (PUSH + ACK)"
 
         self._open_settings_modal(selenium)
-        assert (
-            self._checkbox_state(selenium, "SYNFilterCheckbox") is True
-        ), "SYN checkbox should remain selected after saving"
+        assert self._checkbox_state(selenium, "SYNFilterCheckbox") is True, (
+            "SYN checkbox should remain selected after saving"
+        )
         self._close_options_modal(selenium)
 
     def test_disabling_filters_restores_packets(

--- a/front/tests/test_port_forwarding_tcp_udp.py
+++ b/front/tests/test_port_forwarding_tcp_udp.py
@@ -8,7 +8,6 @@ from utils.networks import MiminetTestNetwork, NodeType
 
 
 class TestPortForwardingTCP:
-
     @pytest.fixture(scope="class", params=["tcp", "udp"])
     def protocol_and_network(self, selenium: MiminetTester, request):
         protocol = request.param

--- a/front/tests/test_router_cycle.py
+++ b/front/tests/test_router_cycle.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeConfig, NodeType
 
 
 class TestRouterCycle:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/test_sleep.py
+++ b/front/tests/test_sleep.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeType
 
 
 class TestSleepJob:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/test_stp.py
+++ b/front/tests/test_stp.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeType
 
 
 class TestSTP:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/test_vlan.py
+++ b/front/tests/test_vlan.py
@@ -6,7 +6,6 @@ from utils.networks import MiminetTestNetwork, NodeConfig, NodeType
 
 
 class TestVLAN:
-
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)

--- a/front/tests/utils/networks.py
+++ b/front/tests/utils/networks.py
@@ -407,9 +407,9 @@ class NodeConfig:
         """Fill default gateway with data."""
         self.__check_config_open()
 
-        assert (
-            self.__config_locator.DEFAULT_GATEWAY_FIELD
-        ), f'Unable to change default gateway for this element: "{self.__config_locator}".'
+        assert self.__config_locator.DEFAULT_GATEWAY_FIELD, (
+            f'Unable to change default gateway for this element: "{self.__config_locator}".'
+        )
 
         gw_field = self.__selenium.find_element(
             By.CSS_SELECTOR, self.__config_locator.DEFAULT_GATEWAY_FIELD.selector
@@ -421,9 +421,9 @@ class NodeConfig:
         """Change device name."""
         self.__check_config_open()
 
-        assert (
-            self.__config_locator.NAME_FIELD
-        ), f'Unable to change name for this element: "{self.__config_locator}".'
+        assert self.__config_locator.NAME_FIELD, (
+            f'Unable to change name for this element: "{self.__config_locator}".'
+        )
 
         name_field = self.__selenium.find_element(
             By.CSS_SELECTOR, self.__config_locator.NAME_FIELD.selector
@@ -559,9 +559,9 @@ class NodeConfig:
         else:
             raise Exception("Can't find device type !!!")
 
-        assert (
-            self.__config_locator.MAIN_FORM
-        ), f'Unable to open node config form for this element: "{self.__config_locator}".'
+        assert self.__config_locator.MAIN_FORM, (
+            f'Unable to open node config form for this element: "{self.__config_locator}".'
+        )
 
         self.__selenium.wait_until_appear(
             By.CSS_SELECTOR, self.__config_locator.MAIN_FORM.selector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,9 @@ ignore = ["E501", "W391", "C901", "E203"]
 quote-style = "double"
 
 [tool.ty]
-python_version = "3.12"
-ignore_missing_imports = true
+
+[[tool.ty.overrides]]
+include = ["**"]
+
+[tool.ty.overrides.analysis]
+allowed-unresolved-imports = ["**"]

--- a/scripts/fetch-example-networks.py
+++ b/scripts/fetch-example-networks.py
@@ -89,7 +89,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--out",
-        default=str(Path(__file__).resolve().parent.parent / "back" / "bench" / "examples"),
+        default=str(
+            Path(__file__).resolve().parent.parent / "back" / "bench" / "examples"
+        ),
         help="output directory for *_network.json files",
     )
     args = parser.parse_args()

--- a/uv.lock
+++ b/uv.lock
@@ -156,38 +156,6 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -471,20 +439,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
-]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mccabe" },
-    { name = "pycodestyle" },
-    { name = "pyflakes" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
 ]
 
 [[package]]
@@ -1115,15 +1069,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
-]
-
-[[package]]
 name = "miminet-back"
 version = "0.1.0"
 source = { virtual = "back" }
@@ -1139,8 +1084,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
-    { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1165,8 +1108,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = "~=26.3" },
-    { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1211,8 +1152,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
-    { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1255,8 +1194,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = "~=26.3" },
-    { name = "flake8" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest", specifier = "==9.0.3" },
@@ -1486,15 +1423,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.11.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/1d/6e762a6b060e662208951aefc5c39f6a96a272c4a10c0c1f7b6113fc3c09/platformdirs-4.11.6.tar.gz", hash = "sha256:1a4016e373f89f8ec458431fe0e0c5c4285858ac623f3e20efdfcbc0bd862941", size = 35131, upload-time = "2026-09-01T04:41:00.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/d8/2784c6eabb991b5b7494ff9e9888c74a0a72ad613c3ec5adbfcecc0724c7/platformdirs-4.11.6-py3-none-any.whl", hash = "sha256:b22d992e863bc651c26b16242041c7979db6e3286e548f9a76cc91238fac599e", size = 23938, upload-time = "2026-09-01T04:40:58.977Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1593,15 +1521,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
 ]
 
 [[package]]
@@ -1704,15 +1623,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyflakes"
-version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1811,35 +1721,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Full lint/formatter switch to **ruff** per the batch plan:

- **commit A** `ci: switch linter to ruff check + ruff format (keep mypy)` — tooling only:
  - `linter.yml`: `flake8` → `ruff check`, `black` → `ruff format --check`; mypy type gate unchanged.
  - back/front dev groups: drop `black~=26.3`, `flake8`; keep `mypy`, `ruff`, `ty`.
  - `uv.lock` refreshed (removes black, flake8, mccabe, pycodestyle, pyflakes, pytokens).
  - `pyproject.toml`: fix invalid `[tool.ty]` block (was not parseable by `ty`; now valid so `ty` can be evaluated for the deferred mypy→ty step).
- **commit B** `style: ruff format sweep across repo` — one dedicated autofix commit, kept separate from the tooling commit so reflog/blame/`rev-list` can isolate the reformat (21 files, 158±158).

## Why mypy stays (deferred)
`ty check .` surfaces **190 diagnostics across ~50 files** (140 `invalid-argument-type`, 28 `not-subscriptable`, …) where `mypy --ignore-missing-imports` reports **0**. mypy's default skips untyped function bodies; ty checks them strictly. A full mypy→ty swap is a type-churn diff touching runtime app code, not a mechanical switch — deferred per the agent guardrails (proportional risk) with the experiment evidence recorded. ruff lint+format is green (0 findings, parity with the old flake8/black config: line-length 88, ignores E501/W391/C901/E203).