### PR TITLE
test(ci): shard back pytest suite across 3 matrix jobs (experiment)

### DIFF
--- a/.github/workflows/back_test.yml
+++ b/.github/workflows/back_test.yml
@@ -10,6 +10,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v7
 
@@ -71,18 +75,25 @@ jobs:
           uv sync --frozen --project back
 
       - name: Test with pytest
+        env:
+          SHARD: ${{ matrix.shard }}
+          N_SHARDS: 3
         run: |
-          sudo bash -c '
+          sudo SHARD="$SHARD" N_SHARDS="$N_SHARDS" bash -c '
             source .venv/bin/activate
             cd back/tests
             export PYTHONPATH=$PYTHONPATH:../src
-            pytest .
+            files=$(find . -name "test_*.py" | sort)
+            slice=$(echo "$files" | awk -v n="$N_SHARDS" -v s="$SHARD" "NR % n == s-1")
+            [ -n "$slice" ] || { echo "ERROR: shard $SHARD/$N_SHARDS got an empty slice" >&2; exit 1; }
+            echo "Shard $SHARD/$N_SHARDS (files: $slice)"
+            pytest $slice
           '
 
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-logs
+          name: test-logs-shard-${{ matrix.shard }}
           path: back/tests/back_test.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Experiment (revival of deferred #475)
The unshare-based pytest-xdist parallelism was proven to break OVS emulation
(empty captures — ovs-vswitchd in the host netns, worker nets in private netns,
verified at 4 workers AND 1 worker). This PR tests the alternative:
**matrix sharding** — N GitHub runners, each runs a serial slice of `back/tests`
by file (round-robin), no `unshare`, no xdist.

- `back_test.yml`: `strategy.matrix.shard: [1,2,3]`; the pytest step picks
  `test_*.py` files where `NR % 3 == shard-1`.
- 4 test files → shards get 1/2/1 files; slices are serial per runner.

## Gate
- **Pass** (all 3 shards green incl. emulation tests `test_miminet_back.py`,
  `test_duplication.py`, `test_network_ready.py`): proves sharding works →
  merge as CI speedup (3× parallel setup).
- **Fail/flaky** on emulation: records a second negative (sharding also breaks),
  the PR gets closed and the parallelism question stays deferred.

## Note
This is purely a CI workflow change (no source diff); Linter on this branch
uses the current upstream config and should stay green.