### PR TITLE
ci(lint): restore invalid-escape coverage (W605)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 88
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "W605"]
 ignore = ["E501", "W391", "C901", "E203"]
 
 [tool.ruff.format]


### PR DESCRIPTION
Follow-up from the ruff switch review (#476): flake8 caught invalid escape
sequences via W605; the ruff select set (`E4/E7/E9/F`) does not. This adds
`W605` back to `[tool.ruff.lint] select`. Repo is clean today (`ruff check .`
passes) — it's a coverage-restoration, not a fix.