### PR TITLE
fix(back): set NO_COLOR in image for iproute2 >= 6.19 pty coloring

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -47,4 +47,10 @@ COPY back/ENTRYPOINT.sh /app/ENTRYPOINT.sh
 RUN chmod +x ovs-init.sh ENTRYPOINT.sh
 COPY back/src /app
 
+# iproute2 >= 6.19 colorizes `ip` output whenever stdout is a TTY. Mininet
+# spawns every host/switch shell on a pseudo-tty, and ipmininet parses
+# `ip address show` output as plain text, so colored output (e.g. an IP
+# wrapped in ANSI escapes) breaks interface configuration. Disable color.
+ENV NO_COLOR=1
+
 ENTRYPOINT ["/app/ENTRYPOINT.sh"]

--- a/back/src/emulator.py
+++ b/back/src/emulator.py
@@ -23,6 +23,13 @@ from network_topology import MiminetTopology
 SERVER_SETTLE_JOBS = frozenset({200, 201, 203})
 SERVER_SETTLE_SECONDS = float(os.environ.get("MIMINET_SERVER_SETTLE", "0.5"))
 
+# iproute2 >= 6.19 colorizes `ip` output whenever stdout is a TTY, and Mininet
+# runs every host/switch shell on a pseudo-tty. ipmininet parses `ip address
+# show` output as plain text, so ANSI-wrapped addresses break interface
+# configuration (empty captures). Disable color for the emulation process and
+# everything it spawns (mininet node shells inherit os.environ).
+os.environ.setdefault("NO_COLOR", "1")
+
 
 def emulate(
     network: Network,


### PR DESCRIPTION
## Problem

The ubuntu 26.04 base bump (#457, closed deferred) breaks back emulation: 20/21 emulation tests fail with **empty packet captures**.

## Root cause (found by local podman debug on a 26.04 image)

iproute2 **6.19** colorizes `ip` output by default **whenever stdout is a TTY** (`-color=auto` default). Mininet spawns every host/switch shell on a **pseudo-tty** (see `mininet/node.py:startShell`), so `ip address show dev <if>` output inside nodes is wrapped in ANSI escapes. ipmininet parses that output as plain text (`ipmininet/link.py:_parse_addresses`) and fails with:

```
AddressValueError: Only decimal digits permitted in '\x1b[1;35m10' in '\x1b[1;35m10.0.0.1\x1b[0m'
```

→ interface IPs never get configured → no traffic → empty captures. Verified by PTY probe: 24.04 (iproute2 6.1.0) emits no color on a PTY, 26.04 (6.19.0) does. `NO_COLOR=1` disables it; `TERM=dumb` does not.

## Fix

`ENV NO_COLOR=1` in `back/Dockerfile` — disables ANSI color in the image for all tools that honor it (iproute2 6.19 does).

## Verification (local rootless-podman harness, the ONLY thing that builds+runs the image; CI Pytest runs on the runner directly and never exercises it)
- ubuntu 26.04 + NO_COLOR image: **42 passed** (was 20 failed / 22 passed)
- ubuntu 24.04 + NO_COLOR image: **42 passed** (no regression; NO_COLOR is a no-op on iproute2 6.1)