### PR TITLE
fix(front/tests): use wait_and_click for config-commit and navigation clicks

### DIFF
--- a/front/tests/conftest.py
+++ b/front/tests/conftest.py
@@ -8,7 +8,11 @@ from unittest.mock import MagicMock
 import pytest
 import requests
 from requests import Session
-from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+)
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -49,17 +53,29 @@ class MiminetTester(WebDriver):
     adding new methods for convenient element interaction.
     """
 
-    def wait_and_click(self, by: str, element: str, timeout=20):
+    def wait_and_click(
+        self,
+        by: str,
+        element: str,
+        timeout=20,
+        scope=None,
+    ):
         """
         Waits for the specified element to become clickable before clicking it.
 
         Re-finds the element on every attempt so a stale element caused by a
         page re-render is not treated as a failure.
 
+        If ``scope`` is given (a WebElement or a ``(by, selector)`` locator
+        tuple), the target element is searched within it on every attempt.
+        This keeps the click bound to e.g. the correct modal dialog when the
+        same inner id exists in several rendered dialogs.
+
         Args:
             by (By): The locator strategy (e.g., By.ID, By.XPATH).
             element (str): The element locator (e.g., "myElementId", "//button[text()='Click Me']").
             timeout (int): The maximum time in seconds to wait (default: 20).
+            scope (WebElement | tuple): Optional container to re-find the element within.
         """
         deadline = time.monotonic() + timeout
         while True:
@@ -69,12 +85,32 @@ class MiminetTester(WebDriver):
                     f"Element {element} is not clickable within {timeout} seconds."
                 )
             try:
-                WebDriverWait(self, remaining).until(
-                    EC.element_to_be_clickable((by, element))
-                ).click()
+                if scope is None:
+                    wait_target = EC.element_to_be_clickable((by, element))
+                else:
+                    container = (
+                        self.find_element(*scope) if isinstance(scope, tuple) else scope
+                    )
+                    wait_target = self.__scoped_element_clickable(
+                        container, by, element
+                    )
+                WebDriverWait(self, remaining).until(wait_target).click()
                 return
             except StaleElementReferenceException:
                 continue
+
+    @staticmethod
+    def __scoped_element_clickable(container, by: str, element: str):
+        """Return the element when it is visible and enabled inside the container."""
+
+        def _condition(_driver):
+            try:
+                el = container.find_element(by, element)
+            except NoSuchElementException:
+                return None
+            return el if el.is_displayed() and el.is_enabled() else None
+
+        return _condition
 
     def drag_and_drop(self, source, target, x: int, y: int):
         """Performs a drag-and-drop action from a source element to a target element.

--- a/front/tests/test_duplication.py
+++ b/front/tests/test_duplication.py
@@ -30,10 +30,10 @@ class TestDuplicateBasic:
         dup_field.clear()
         dup_field.send_keys("30")
 
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR,
             Location.Network.ConfigPanel.Edge.SUBMIT_BUTTON.selector,
-        ).click()
+        )
 
         selenium.wait_for(
             lambda _: network.edges[0]["data"].get("duplicate_percentage") == "30"
@@ -58,10 +58,14 @@ class TestDuplicateCopyNetwork:
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Edge.DUPLICATE_FIELD.selector
         ).send_keys("50")
 
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR,
             Location.Network.ConfigPanel.Edge.SUBMIT_BUTTON.selector,
-        ).click()
+        )
+
+        selenium.wait_for(
+            lambda _: network.edges[0]["data"].get("duplicate_percentage") == "50"
+        )
 
         yield network
         network.delete()
@@ -74,15 +78,15 @@ class TestDuplicateCopyNetwork:
 
         initial_edges = network.edges
 
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, Location.Network.TopButton.COPY.selector
-        ).click()
+        )
 
         selenium.wait_until_appear(By.XPATH, Location.Network.MODAL_DIALOG.xpath)
 
-        selenium.find_element(
+        selenium.wait_and_click(
             By.XPATH, Location.Network.ModalButton.GO_TO_EDITING.xpath
-        ).click()
+        )
 
         copy_net = MiminetTestNetwork(selenium, selenium.current_url)
 

--- a/front/tests/test_duplication.py
+++ b/front/tests/test_duplication.py
@@ -5,11 +5,37 @@ from utils.locators import Location
 from utils.networks import MiminetTestNetwork, NodeType
 
 
+def _server_edge_duplicate(
+    selenium: MiminetTester, network: MiminetTestNetwork, expected: str
+) -> bool:
+    """Poll the server-rendered duplicate value via an in-page fetch.
+
+    The edge-config form updates the in-memory JS graph before the save XHR
+    completes. Reloading the page would abort that still-in-flight XHR, so a
+    fresh copy of the network page is fetched from within the page itself and
+    the served ``var edges`` literal is inspected instead.
+    """
+    script = """
+        var url = arguments[0];
+        var done = arguments[1];
+        fetch(url, {cache: 'no-store', credentials: 'include'})
+            .then(function (r) { return r.text(); })
+            .then(function (html) {
+                var m = html.match(/var edges = (.+?);\\s*var jobs/);
+                if (!m) { done(null); return; }
+                var dm = m[1].match(/duplicate_percentage['\"]?\\s*:\\s*['\"]?([0-9]+)['\"]?/);
+                done(dm ? dm[1] : null);
+            })
+            .catch(function () { done(null); });
+    """
+    value = selenium.execute_async_script(script, network.url)
+    return value == expected
+
+
 class TestDuplicateBasic:
     @pytest.fixture(scope="class")
     def network(self, selenium: MiminetTester):
         network = MiminetTestNetwork(selenium)
-
         h1 = network.add_node(NodeType.Host)
         h2 = network.add_node(NodeType.Host)
         network.add_edge(h1, h2)
@@ -63,9 +89,10 @@ class TestDuplicateCopyNetwork:
             Location.Network.ConfigPanel.Edge.SUBMIT_BUTTON.selector,
         )
 
-        selenium.wait_for(
-            lambda _: network.edges[0]["data"].get("duplicate_percentage") == "50"
-        )
+        # The JS sets the in-memory edge value before the save XHR completes,
+        # so poll the server (in-page fetch, no navigation) until the persisted
+        # value is visible; otherwise the copy test may read the pre-save state.
+        selenium.wait_for(lambda _: _server_edge_duplicate(selenium, network, "50"))
 
         yield network
         network.delete()

--- a/front/tests/test_network_menu.py
+++ b/front/tests/test_network_menu.py
@@ -1,6 +1,5 @@
 import pytest
 from conftest import HOME_PAGE, MAIN_PAGE, MiminetTester
-from selenium.webdriver import Chrome
 from selenium.webdriver.common.by import By
 from utils.locators import Location
 from utils.networks import MiminetTestNetwork
@@ -15,12 +14,12 @@ class TestNetworkMenu:
 
         empty_network.delete()
 
-    def test_my_networks_button_press(self, selenium: Chrome):
+    def test_my_networks_button_press(self, selenium: MiminetTester):
         """Checks if it is possible to get to the network selection menu"""
         selenium.get(MAIN_PAGE)
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, Location.NavigationButton.MY_NETWORKS_BUTTON.selector
-        ).click()
+        )
 
         assert selenium.current_url == HOME_PAGE
 
@@ -36,8 +35,8 @@ class TestNetworkMenu:
     def test_new_network_open(self, selenium: MiminetTester, empty_network: str):
         """Checks is it possible to open new network via home menu"""
         selenium.get(HOME_PAGE)
-        selenium.find_element(
+        selenium.wait_and_click(
             By.XPATH, Location.MyNetworks.get_network_button_xpath(0)
-        ).click()
+        )
 
         assert empty_network == selenium.current_url

--- a/front/tests/test_packet_filters.py
+++ b/front/tests/test_packet_filters.py
@@ -54,9 +54,9 @@ class TestPacketFilters:
         )
 
     def _open_settings_modal(self, selenium: MiminetTester):
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, Location.Network.TopButton.OPTIONS.selector
-        ).click()
+        )
         selenium.wait_until_appear(By.CSS_SELECTOR, "#netConfigModal")
         self._wait_filters_ready(selenium)
 
@@ -69,10 +69,9 @@ class TestPacketFilters:
             selenium.wait_until_appear(By.CSS_SELECTOR, locator.selector)
 
     def _save_network_options(self, selenium: MiminetTester):
-        submit_button = selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, Location.Network.Options.SUBMIT_BUTTON.selector
         )
-        submit_button.click()
         selenium.wait_for(
             lambda driver: driver.execute_script(
                 "return !document.querySelector('#netConfigModal')"
@@ -88,8 +87,7 @@ class TestPacketFilters:
             " || $('#netConfigModal').is(':hidden');"
         ):
             return
-        cancel_button = selenium.find_element(By.ID, cancel_button_id)
-        cancel_button.click()
+        selenium.wait_and_click(By.ID, cancel_button_id)
         selenium.wait_for(
             lambda driver: driver.execute_script(
                 "return !document.querySelector('#netConfigModal')"

--- a/front/tests/test_ping_and_copy.py
+++ b/front/tests/test_ping_and_copy.py
@@ -49,14 +49,14 @@ class TestPingAndCopy:
         edges = network.edges
         jobs = network.jobs
 
-        selenium.find_element(
+        selenium.wait_and_click(
             By.CSS_SELECTOR, Location.Network.TopButton.COPY.selector
-        ).click()
+        )
         selenium.wait_until_appear(By.XPATH, Location.Network.MODAL_DIALOG.xpath)
 
-        selenium.find_element(
+        selenium.wait_and_click(
             By.XPATH, Location.Network.ModalButton.GO_TO_EDITING.xpath
-        ).click()
+        )
 
         copy_network = MiminetTestNetwork(selenium, selenium.current_url)
 

--- a/front/tests/utils/networks.py
+++ b/front/tests/utils/networks.py
@@ -327,6 +327,7 @@ class NodeConfig:
             self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.STP_BUTTON.selector,
+                scope=modal_el,
             )
 
             priority_field = dialog.find_element(
@@ -339,6 +340,7 @@ class NodeConfig:
             self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.SUBMIT_BUTTON.selector,
+                scope=modal_el,
             )
 
     def disable_stp(self):
@@ -361,11 +363,13 @@ class NodeConfig:
             self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.OFF_STP_BUTTON.selector,
+                scope=modal_el,
             )
 
             self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.SUBMIT_BUTTON.selector,
+                scope=modal_el,
             )
 
     def add_jobs(self, job_id: int, args: dict[str, str], by=By.CSS_SELECTOR):
@@ -454,6 +458,7 @@ class NodeConfig:
             self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.VlanPanel.SWITCH_BUTTON.selector,
+                scope=modal,
             )
 
             # Go through each row
@@ -495,6 +500,7 @@ class NodeConfig:
             self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.VlanPanel.SUBMIT_BUTTON.selector,
+                scope=modal,
             )
 
     def submit(self):

--- a/front/tests/utils/networks.py
+++ b/front/tests/utils/networks.py
@@ -231,9 +231,9 @@ class MiminetTestNetwork:
         """Delete current network."""
         self.__check_page()
 
-        self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR, Location.Network.TopButton.OPTIONS.selector
-        ).click()
+        )
 
         self.__selenium.wait_and_click(
             By.CSS_SELECTOR,
@@ -311,10 +311,10 @@ class NodeConfig:
         """Switch the FTP configuration toggle."""
         self.__check_config_open()
 
-        self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR,
             Location.Network.ConfigPanel.Switch.RSTP_BUTTON.selector,
-        ).click()
+        )
 
         modal_el = (
             By.CSS_SELECTOR,
@@ -324,10 +324,10 @@ class NodeConfig:
         )
 
         with self.__selenium.run_in_modal_context(*modal_el) as dialog:
-            dialog.find_element(
+            self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.STP_BUTTON.selector,
-            ).click()
+            )
 
             priority_field = dialog.find_element(
                 By.CSS_SELECTOR,
@@ -336,19 +336,19 @@ class NodeConfig:
             priority_field.clear()
             priority_field.send_keys(str(priority))
 
-            dialog.find_element(
+            self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.SUBMIT_BUTTON.selector,
-            ).click()
+            )
 
     def disable_stp(self):
         """Switch the FTP configuration toggle."""
         self.__check_config_open()
 
-        self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR,
             Location.Network.ConfigPanel.Switch.RSTP_BUTTON.selector,
-        ).click()
+        )
 
         modal_el = (
             By.CSS_SELECTOR,
@@ -357,16 +357,16 @@ class NodeConfig:
             ),
         )
 
-        with self.__selenium.run_in_modal_context(*modal_el) as dialog:
-            dialog.find_element(
+        with self.__selenium.run_in_modal_context(*modal_el) as _:
+            self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.OFF_STP_BUTTON.selector,
-            ).click()
+            )
 
-            dialog.find_element(
+            self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.StpPanel.SUBMIT_BUTTON.selector,
-            ).click()
+            )
 
     def add_jobs(self, job_id: int, args: dict[str, str], by=By.CSS_SELECTOR):
         """Adds a job to the system using Selenium.
@@ -439,10 +439,9 @@ class NodeConfig:
         """
         switch_name = self.name
 
-        vlan_config_button = self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR, Location.Network.ConfigPanel.Switch.VLAN_BUTTON.selector
         )
-        vlan_config_button.click()
 
         modal = (
             By.CSS_SELECTOR,
@@ -452,12 +451,10 @@ class NodeConfig:
         )
 
         with self.__selenium.run_in_modal_context(*modal) as dialog:
-            switch_button = dialog.find_element(
+            self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.VlanPanel.SWITCH_BUTTON.selector,
             )
-
-            switch_button.click()
 
             # Go through each row
             row_id = 0
@@ -495,25 +492,24 @@ class NodeConfig:
                 row_id += 1
 
             # Save new table
-            submit_button = dialog.find_element(
+            self.__selenium.wait_and_click(
                 By.CSS_SELECTOR,
                 Location.Network.ConfigPanel.Switch.VlanPanel.SUBMIT_BUTTON.selector,
             )
-            submit_button.click()
 
     def submit(self):
         """Submit configuration."""
         self.__check_config_open()
 
-        self.__selenium.find_element(
+        self.__selenium.wait_and_click(
             By.CSS_SELECTOR, self.__config_locator.SUBMIT_BUTTON.selector
-        ).click()
+        )
 
         self.__selenium.wait_until_text(
             By.CSS_SELECTOR,
             self.__config_locator.SUBMIT_BUTTON.selector,
             self.__config_locator.SUBMIT_BUTTON.text,
-            timeout=5,
+            timeout=20,
         )
 
     def __select_job(self, job_id, by):


### PR DESCRIPTION
## Summary
Convert raw Selenium clicks to the stale-tolerant `MiminetTester.wait_and_click` (re-finds + retries on `StaleElementReferenceException`) in **config-commit** and **navigation** paths, so a modal/config-panel re-render that invalidates a cached element no longer silently swallows the click (config never saved).

Also await edge `duplicate_percentage` persistence after submit in `TestDuplicateCopyNetwork` instead of yielding before the save lands.

## Motivation (CI flake, Full test on main 2026-09-01 run 33534412090)
- `test_stp` ERROR at setup: `stale element reference` in `submit()` (`networks.py`), `113 passed, 1 error`.
- `test_duplication` intermittent `assert 50 == 0`: edge config submit click missed, so the copy was taken from an unsaved network.

## Scope
- A (config-commit): `submit`, `enable_stp`, `disable_stp`, `vlan_config` (open + modal submit), `delete()` OPTIONS.
- B (navigation): COPY, GO_TO_EDITING, MY_NETWORKS, open-network button.
- Held out intentionally: checkbox toggles (retry could double-toggle) and the JS-bypass delete fallback (`execute_script`) in `test_packet_filters`.

## Verification (local, host rootless podman, same engine as back harness)
- Full frontend stack + Selenium grid (chrome 141) brought up with a `.tmp` compose override (host port remap + env neutralization; `TEST_TARGET_HOST=10.38.104.166:8080` reachable from both host and chrome container).
- Pre-fix repro of `test_stp` + `test_duplication`: **15 runs, 1 failure** — the exact `assert 50 == 0` flake.
- Post-fix repro: **10 runs, 0 failures**.
- Full `front/tests` suite: **114 passed** in ~6.5 min.
- `mypy --ignore-missing-imports front`, `ruff format --check front`, `ruff check front`: clean.