### PR TITLE
test(ci): shard front full test across 3 matrix jobs

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -13,6 +13,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout code
@@ -50,8 +54,25 @@ jobs:
           curl -f localhost
 
       - name: Run tests
+        env:
+          SHARD: ${{ matrix.shard }}
+          N_SHARDS: 3
         run: |
-          sudo bash -c '
+          sudo SHARD="$SHARD" N_SHARDS="$N_SHARDS" bash -c '
             source .venv/bin/activate
-            python -m pytest -vv -s front/tests
+            mkdir -p .tmp
+            files=$(find front/tests -maxdepth 1 -name "test_*.py" | sort)
+            slice=$(echo "$files" | awk -v n="$N_SHARDS" -v s="$SHARD" "NR % n == s-1")
+            [ -n "$slice" ] || { echo "ERROR: shard $SHARD/$N_SHARDS got an empty slice" >&2; exit 1; }
+            echo "Shard $SHARD/$N_SHARDS (files: $slice)"
+            set -o pipefail
+            python -m pytest -vv -s $slice 2>&1 | tee .tmp/full-test-shard-$SHARD.log
           '
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: full-test-logs-shard-${{ matrix.shard }}
+          path: .tmp/full-test-shard-${{ matrix.shard }}.log
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes nothing; infra hardening of the flake-signal job, mirroring the merged back-suite sharding (b968192, #477).

**Problem.** `Full test` (front Selenium e2e, 114 tests / 25 files) runs as one serial job behind one session-scoped browser. Wall clock ~6 min; a single tab-crash cascades to every later test (one incident, not N); no per-shard logs survive a failed job.

**Change.** Convert the `build` job to a 3-runner matrix (`fail-fast: false`):
- each runner boots its own frontend + selenium-grid compose stack (independent DB/grid, no cross-runner coupling),
- runs a round-robin file slice of `front/tests/test_*.py` (`find | sort | awk 'NR % n == s-1'`, 25 files → 8/9/8),
- empty-slice guard (`[ -n "$slice" ] || exit 1`) so a future file-count change can never silently run the whole suite on one shard,
- `set -o pipefail` + `tee` preserves pytest's exit code while capturing the full log,
- per-shard `upload-artifact` (`if: always()`, `if-no-files-found: ignore`).

**Gates.** Slice math reproduced locally (8/9/8, union 25, no empty). YAML parses (python3 + ruby). Alphabetical order within each slice preserves today's serial file ordering, so no cross-file ordering regression. This PR's own Full-test matrix runs are the workflow gate.