### PR TITLE
test(ci): harden shard slicing with quoted arrays, pipefail, log capture

### DIFF
--- a/.github/workflows/back_test.yml
+++ b/.github/workflows/back_test.yml
@@ -80,14 +80,24 @@ jobs:
           N_SHARDS: 3
         run: |
           sudo SHARD="$SHARD" N_SHARDS="$N_SHARDS" bash -c '
+            set -euo pipefail
             source .venv/bin/activate
             cd back/tests
-            export PYTHONPATH=$PYTHONPATH:../src
-            files=$(find . -name "test_*.py" | sort)
-            slice=$(echo "$files" | awk -v n="$N_SHARDS" -v s="$SHARD" "NR % n == s-1")
-            [ -n "$slice" ] || { echo "ERROR: shard $SHARD/$N_SHARDS got an empty slice" >&2; exit 1; }
-            echo "Shard $SHARD/$N_SHARDS (files: $slice)"
-            pytest $slice
+            export PYTHONPATH=${PYTHONPATH:-}:../src
+            files=$(find . -name "test_*.py" | sort) || { echo "ERROR: find/sort failed" >&2; exit 1; }
+            slice=()
+            idx=0
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              idx=$((idx + 1))
+              if [ $((idx % N_SHARDS)) -eq $((SHARD - 1)) ]; then
+                slice+=("$f")
+              fi
+            done <<<"$files"
+            [ "${#slice[@]}" -gt 0 ] || { echo "ERROR: shard $SHARD/$N_SHARDS got an empty slice" >&2; exit 1; }
+            echo "Shard $SHARD/$N_SHARDS (${#slice[@]} files)"
+            printf '%s\n' "${slice[@]}"
+            python -m pytest -vv -s -o log_file=/dev/null -o log_cli=true -o log_cli_level=INFO "${slice[@]}" 2>&1 | tee back_test.log
           '
 
       - name: Upload test logs

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -75,14 +75,27 @@ jobs:
           N_SHARDS: 3
         run: |
           sudo SHARD="$SHARD" N_SHARDS="$N_SHARDS" bash -c '
+            set -euo pipefail
             source .venv/bin/activate
             mkdir -p .tmp
-            files=$(find front/tests -maxdepth 1 -name "test_*.py" | sort)
-            slice=$(echo "$files" | awk -v n="$N_SHARDS" -v s="$SHARD" "NR % n == s-1")
-            [ -n "$slice" ] || { echo "ERROR: shard $SHARD/$N_SHARDS got an empty slice" >&2; exit 1; }
-            echo "Shard $SHARD/$N_SHARDS (files: $slice)"
-            set -o pipefail
-            python -m pytest -vv -s $slice 2>&1 | tee .tmp/full-test-shard-$SHARD.log
+            # -maxdepth 1: only flat front/tests/test_*.py files participate in
+            # sharding. A future test file under front/tests/<subdir>/ will NOT
+            # be collected; revisit the shard partition if sub-suite discovery
+            # is ever wanted.
+            files=$(find front/tests -maxdepth 1 -name "test_*.py" | sort) || { echo "ERROR: find/sort failed" >&2; exit 1; }
+            slice=()
+            idx=0
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              idx=$((idx + 1))
+              if [ $((idx % N_SHARDS)) -eq $((SHARD - 1)) ]; then
+                slice+=("$f")
+              fi
+            done <<<"$files"
+            [ "${#slice[@]}" -gt 0 ] || { echo "ERROR: shard $SHARD/$N_SHARDS got an empty slice" >&2; exit 1; }
+            echo "Shard $SHARD/$N_SHARDS (${#slice[@]} files)"
+            printf '%s\n' "${slice[@]}"
+            python -m pytest -vv -s "${slice[@]}" 2>&1 | tee .tmp/full-test-shard-$SHARD.log
           '
 
       - name: Capture container logs
@@ -111,4 +124,5 @@ jobs:
         with:
           name: full-test-logs-shard-${{ matrix.shard }}
           path: .tmp/*-shard-${{ matrix.shard }}.log
+          include-hidden-files: true
           if-no-files-found: ignore


### PR DESCRIPTION
Closes the review-gate nits from #477/#483 (approved non-blocking, left latent).

- Quoted bash arrays replace unquoted `$slice` (word-split/glob self-match hole silently drops a shard file).
- `set -euo pipefail` atop each sudo block: pytest exit code survives the tee; find/sort failures fail loudly.
- Partition byte-identical to old `awk NR % n == s-1` (equivalence verified locally for n∈{2,3,5}, edge + real lists).
- back_test.yml captures `back_test.log` (its pre-existing upload-artifact was a silent no-op) + `-vv -s`.