### PR TITLE
ci(lint): gate with ty (src strict; tests staged) + make back/front src ty-clean

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,9 +34,9 @@ jobs:
         run: |
           uv sync --frozen
 
-      - name: Lint with mypy
+      - name: Lint with ty
         run: |
-          uv run --frozen mypy --ignore-missing-imports ${{matrix.node}}
+          uv run --frozen ty check --no-progress ${{matrix.node}}
 
       - name: Format with ruff
         run: |

--- a/back/bench/bench.py
+++ b/back/bench/bench.py
@@ -70,7 +70,6 @@ def ovs_vswitchd_rss():
         except (
             psutil.NoSuchProcess,
             psutil.AccessDenied,
-            psutil.ProcessLookupError,
             psutil.ZombieProcess,
         ):
             continue
@@ -97,7 +96,6 @@ class Sampler:
                     except (
                         psutil.NoSuchProcess,
                         psutil.AccessDenied,
-                        psutil.ProcessLookupError,
                         psutil.ZombieProcess,
                     ):
                         pass
@@ -105,7 +103,6 @@ class Sampler:
             except (
                 psutil.NoSuchProcess,
                 psutil.AccessDenied,
-                psutil.ProcessLookupError,
                 psutil.ZombieProcess,
             ):
                 break

--- a/back/src/network_topology.py
+++ b/back/src/network_topology.py
@@ -80,15 +80,18 @@ class MiminetTopology(IPTopo):
 
     def __handle_router(self, node_id: str, config: NodeConfig):
         default_gw = config.default_gw
-        kwargs = {
-            "use_v6": False,
-            "config": RouterConfig,
-        }
 
         if default_gw:
-            kwargs["routerDefaultRoute"] = f"via {default_gw}"
+            router = self.addRouter(
+                node_id,
+                use_v6=False,
+                config=RouterConfig,
+                routerDefaultRoute=f"via {default_gw}",
+            )
+        else:
+            router = self.addRouter(node_id, use_v6=False, config=RouterConfig)
 
-        self.__nodes[node_id] = self.addRouter(node_id, **kwargs)
+        self.__nodes[node_id] = router
 
     def __find_interface(
         self, edge_id: str, node_interfaces: list[NodeInterface]
@@ -177,7 +180,7 @@ class MiminetTopology(IPTopo):
             )
 
             # Put virtual switch between nodes and return link between them
-            link1, link2 = self.addLink(
+            link1, link2 = self._add_link_via_switch(
                 src_host,
                 trg_host,
                 interface_name_1=src_iface.name,
@@ -210,7 +213,7 @@ class MiminetTopology(IPTopo):
             )
         super().build(*args, **kwargs)
 
-    def addLink(
+    def _add_link_via_switch(
         self,
         h_source,
         h_target,
@@ -221,7 +224,11 @@ class MiminetTopology(IPTopo):
         loss_percentage=0,
         duplicate_percentage=0,
     ):
-        """Connects two hosts through a virtual switch."""
+        """Connect two hosts through a freshly-created virtual switch.
+
+        Returns the (host<->switch, switch<->host) link pair. This is NOT an
+        IPTopo.addLink override (which links two named nodes directly): it is
+        an internal helper that inserts an extra hub switch on the path."""
         # Create unique switch name
         self.__switch_count += 1
         switch_name = "mimiswsw%d" % self.__switch_count

--- a/back/src/pkt_parser.py
+++ b/back/src/pkt_parser.py
@@ -1,6 +1,7 @@
 import os
 import random
 import string
+from typing import cast
 
 import dpkt
 from dpkt.pcap import Reader
@@ -39,12 +40,21 @@ def is_dhcp(udp) -> bool:
         return False
 
 
+def _dhcp_opt_bytes(opts: dict, code: int) -> bytes:
+    """Return a DHCP option payload as bytes.
+
+    dpkt stores option values as ``bytes`` (raw wire data); its annotations
+    advertise ``str`` for some options, so coerce for the type checker only."""
+    value = opts.get(code, b"")
+    return value if isinstance(value, bytes) else cast(bytes, value)
+
+
 def udp_packet_type(pkt) -> str:
     if is_dhcp(pkt):
         dh = dpkt.dhcp.DHCP(pkt.data)
         opts = dict(dh.opts)
         msg_type = int.from_bytes(
-            opts.get(dpkt.dhcp.DHCP_OPT_MSGTYPE, b""), byteorder="big"
+            _dhcp_opt_bytes(opts, dpkt.dhcp.DHCP_OPT_MSGTYPE), byteorder="big"
         )
         match msg_type:
             case dpkt.dhcp.DHCPDISCOVER:
@@ -53,13 +63,14 @@ def udp_packet_type(pkt) -> str:
                 ip = dh.yiaddr
                 mask = bin(
                     int.from_bytes(
-                        opts.get(dpkt.dhcp.DHCP_OPT_NETMASK, b""), byteorder="big"
+                        _dhcp_opt_bytes(opts, dpkt.dhcp.DHCP_OPT_NETMASK),
+                        byteorder="big",
                     )
                 ).count("1")
                 return f"DHCP Offer {int_to_ip(ip)}/{mask}"
             case dpkt.dhcp.DHCPREQUEST:
                 ip = int.from_bytes(
-                    opts.get(dpkt.dhcp.DHCP_OPT_REQ_IP, b""), byteorder="big"
+                    _dhcp_opt_bytes(opts, dpkt.dhcp.DHCP_OPT_REQ_IP), byteorder="big"
                 )
                 return f"DHCP Request {int_to_ip(ip)}"
             case dpkt.dhcp.DHCPDECLINE:

--- a/front/src/app.py
+++ b/front/src/app.py
@@ -621,7 +621,11 @@ def sitemap():
         if "admin/" in rule.rule:
             continue
 
-        if "GET" in rule.methods and len(rule.arguments) == 0:
+        if (
+            rule.methods is not None
+            and "GET" in rule.methods
+            and len(rule.arguments) == 0
+        ):
             pages.append(["https://miminet.ru" + str(rule.rule), zero_days_ago])
 
     sitemap_xml = render_template("sitemap_template.xml", pages=pages)

--- a/front/src/auth_tests/tg_test.py
+++ b/front/src/auth_tests/tg_test.py
@@ -54,6 +54,7 @@ def auth_data():
 def create_hash():
     bot_token_secret = os.environ.get("BOT_TOKEN")
     BOT_TOKEN = json.loads(bot_token_secret) if bot_token_secret else None
+    assert BOT_TOKEN is not None, "BOT_TOKEN env var is not set"
     auth_data = {"id": "hash", "auth_date": str(int(time.time()))}
     data_check_arr = [f"{key}={value}" for key, value in auth_data.items()]
     data_check_arr.sort()

--- a/front/src/configurators.py
+++ b/front/src/configurators.py
@@ -209,6 +209,7 @@ class AbstractConfigurator(ABC):
 
     def __conf_sims_delete(self):
         """Delete saved simulations. Typically used at the end of the configuration"""
+        assert self._cur_network is not None
         sims = Simulate.query.filter(Simulate.network_id == self._cur_network.id).all()
         for s in sims:
             app.control.revoke(s.task_guid, terminate=False)
@@ -235,7 +236,7 @@ class AbstractConfigurator(ABC):
 class AbstractNodeConfigurator(AbstractConfigurator):
     def __init__(self, element_type: str):
         super().__init__(element_type)
-        self._node = None
+        self._node: dict | None = None
         self._nodes: list = []
 
     def _conf_prepare_node(self):
@@ -257,6 +258,7 @@ class AbstractNodeConfigurator(AbstractConfigurator):
 
     def _conf_label_update(self):
         """Update device label(name). Typically used at the end of the configuration"""
+        assert self._node is not None
         # get label with device name
         label = get_data(f"config_{self._element_type}_name")
 
@@ -289,6 +291,7 @@ class AbstractDeviceConfigurator(AbstractNodeConfigurator):
 
     def _conf_jobs(self):
         """Configure jobs added to the device"""
+        assert self._node is not None
         job_id_str = get_data(f"config_{self._element_type}_job_select_field")
 
         if not job_id_str:
@@ -338,7 +341,11 @@ class AbstractDeviceConfigurator(AbstractNodeConfigurator):
         current_time = sum(int(j["arg_1"]) for j in sleep_job_list)
 
         if job_id == self.__SLEEP_JOB_ID:
-            new_job_arg = int(job_conf_res["arg_1"])
+            sleep_arg = job_conf_res["arg_1"]
+            assert isinstance(
+                sleep_arg, str
+            )  # sleep time arg is a validated digit string
+            new_job_arg = int(sleep_arg)
             if current_time + new_job_arg > 60:
                 raise ConfigurationError(
                     f"Превышен лимит по времени для команды sleep ({self.__MAX_SLEEP_TIME} секунд на сеть)"
@@ -360,6 +367,7 @@ class AbstractDeviceConfigurator(AbstractNodeConfigurator):
 
     def _conf_ip_addresses(self):
         """Configurate device IP-addresses"""
+        assert self._node is not None
 
         # all interfaces
         iface_ids = request.form.getlist(f"config_{self._element_type}_iface_ids[]")
@@ -408,6 +416,7 @@ class AbstractDeviceConfigurator(AbstractNodeConfigurator):
             interface["netmask"] = mask_value
 
     def _conf_gw(self):
+        assert self._node is not None
         default_gw = get_data(f"config_{self._element_type}_default_gw")
 
         if default_gw:
@@ -434,6 +443,7 @@ class TextboxConfigurator(AbstractNodeConfigurator):
         super().__init__(element_type="textbox")
 
     def _conf_content_update(self):
+        assert self._node is not None
         label = get_data(f"config_{self._element_type}_content")
         fontsize = get_data("config_textbox_font_size")
         font_color = get_data("config_textbox_font_color")
@@ -469,6 +479,7 @@ class SwitchConfigurator(AbstractDeviceConfigurator):
 
     def _configure(self):
         self._conf_prepare_node()
+        assert self._node is not None
         self._conf_label_update()
         res = {}
         try:  # catch argument check errors

--- a/front/src/miminet_admin.py
+++ b/front/src/miminet_admin.py
@@ -12,6 +12,7 @@ from flask_login import current_user
 from markupsafe import Markup
 from sqlalchemy import func
 from sqlalchemy.orm import selectinload
+from typing import Any, cast
 from wtforms import (
     SelectField,
     TextAreaField,
@@ -108,8 +109,12 @@ def _get_admin_tests(user_id):
             Test.is_deleted.is_(False),
         )
         .options(
-            selectinload(Test.sections).selectinload(Section.quiz_sessions),
-            selectinload(Test.sections).selectinload(Section.questions),
+            selectinload(cast(Any, Test.sections)).selectinload(
+                cast(Any, Section.quiz_sessions)
+            ),
+            selectinload(cast(Any, Test.sections)).selectinload(
+                cast(Any, Section.questions)
+            ),
         )
         .order_by(Test.created_on.desc())
         .all()
@@ -203,8 +208,10 @@ def _build_statistics_data(tests):
         )
         .filter(latest_sessions_subquery.c.row_num == 1)
         .options(
-            selectinload(QuizSession.sessions).selectinload(SessionQuestion.question),
-            selectinload(QuizSession.created_by_user),
+            selectinload(cast(Any, QuizSession.sessions)).selectinload(
+                cast(Any, SessionQuestion.question)
+            ),
+            selectinload(cast(Any, QuizSession.created_by_user)),
         )
         .all()
     )
@@ -266,9 +273,9 @@ def _build_statistics_data(tests):
 
     rows.sort(
         key=lambda row: (
-            -row["total_score"],
-            -row["completed_sections"],
-            row["user_name"].casefold(),
+            -cast(int, row["total_score"]),
+            -cast(int, row["completed_sections"]),
+            cast(str, row["user_name"]).casefold(),
         )
     )
 
@@ -342,7 +349,7 @@ class MiminetAdminModelView(ModelView):
     MY_DEFAULT_FORMATTERS.update(
         {
             type(None): typefmt.null_formatter,
-            date: lambda view, value: value.strftime("%d.%m.%Y"),
+            date: lambda view, value, name: value.strftime("%d.%m.%Y"),
         }
     )
 
@@ -540,9 +547,9 @@ class QuestionView(MiminetAdminModelView):
     }
 
     column_formatters = {
-        "created_by_id": created_by_formatter,  # type: ignore
-        "section_id": get_section_name,  # type: ignore
-        "question_type": get_question_type,  # type: ignore
+        "created_by_id": created_by_formatter,
+        "section_id": get_section_name,
+        "question_type": get_question_type,
         "text": lambda v, c, model, n, **kwargs: Markup.unescape(model.text),
     }
 

--- a/front/src/miminet_auth.py
+++ b/front/src/miminet_auth.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import time
 import uuid
+from typing import cast
 
 import google.auth.transport.requests
 import requests
@@ -18,6 +19,7 @@ from flask import (
     url_for,
     jsonify,
     abort,
+    Response,
 )
 from flask_jwt_extended import (
     create_access_token,
@@ -39,6 +41,7 @@ from miminet_config import make_example_net_switch_and_hub
 from miminet_model import Network, User, db
 from oauthlib.oauth2 import TokenExpiredError
 from pip._vendor import cachecontrol
+from pip._vendor.requests.sessions import Session as _VendoredSession
 from requests_oauthlib import OAuth2Session
 from sqlalchemy.exc import SQLAlchemyError
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -257,7 +260,9 @@ def login_index():
         password = request.form.get("password")
         user = User.query.filter_by(email=email).first()
         if user:
-            if check_password_hash(user.password_hash, password):
+            if password is not None and check_password_hash(
+                user.password_hash, password
+            ):
                 login_user(user, remember=True)
                 access_token = create_access_token(identity=str(user.id))
                 refresh_token = create_refresh_token(identity=str(user.id))
@@ -429,7 +434,7 @@ def _load_user_config(user: User) -> dict:
 
 @login_required
 def animation_filters():
-    user = current_user
+    user = cast(User, current_user)
     user_config = _load_user_config(user)
 
     # Ensure defaults are present
@@ -466,7 +471,7 @@ def logout():
     session.pop("next_url", None)
     logout_user()
     response = redirect(url_for("index"))
-    unset_jwt_cookies(response)
+    unset_jwt_cookies(cast(Response, response))
     return response
 
 
@@ -518,7 +523,7 @@ def google_callback():
 
     credentials = flow.credentials
     request_session = requests.session()
-    cached_session = cachecontrol.CacheControl(request_session)
+    cached_session = cachecontrol.CacheControl(cast(_VendoredSession, request_session))
     token_request = google.auth.transport.requests.Request(session=cached_session)
 
     id_info = id_token.verify_oauth2_token(
@@ -734,6 +739,7 @@ def vk_callback():
 
 
 def yandex_login(yandex_json=yandex_json):
+    assert yandex_json is not None, "client_yandex.json is not configured"
     _start_social_link("yandex")
     yandex_session = OAuth2Session(
         yandex_json["web"]["client_id"],
@@ -750,6 +756,7 @@ def yandex_login(yandex_json=yandex_json):
 
 
 def yandex_callback(yandex_json=yandex_json):
+    assert yandex_json is not None, "client_yandex.json is not configured"
     state = session.get("state")
     if not state:
         return redirect(url_for("login_index"))
@@ -813,6 +820,7 @@ def yandex_callback(yandex_json=yandex_json):
 
 
 def check_tg_authorization(auth_data, tg_json=tg_json):
+    assert tg_json is not None, "client_tg.json is not configured"
     BOT_TOKEN = tg_json["token"]["BOT_TOKEN"]
     check_hash = auth_data["hash"]
     del auth_data["hash"]

--- a/front/src/miminet_network.py
+++ b/front/src/miminet_network.py
@@ -571,12 +571,14 @@ def get_last_emulation_time():
 @jwt_required()
 def get_emulation_queue_size():
     """Answer with current emulation queue size filtered by emulation time."""
-    time_filter_req: str = request.args.get("time-filter", type=str).replace(" ", "+")
-    time_filter: datetime.datetime = datetime.datetime.fromisoformat(time_filter_req)
-    if not time_filter:
+    time_filter_req = request.args.get("time-filter", type=str)
+    if not time_filter_req:
         return make_response(
             jsonify({"message": "Пропущен параметр 'time-filter'."}), 400
         )
+    time_filter: datetime.datetime = datetime.datetime.fromisoformat(
+        time_filter_req.replace(" ", "+")
+    )
 
     emulated_networks_count = (
         SimulateLog.query.filter(not_(SimulateLog.ready))

--- a/front/src/quiz/controller/image_controller.py
+++ b/front/src/quiz/controller/image_controller.py
@@ -34,13 +34,14 @@ def upload_image_endpoint():
         return jsonify({"error": "No file field in form-data"}), 400
 
     file = request.files["file"]
-    if file.filename == "":
+    filename = file.filename
+    if not filename:
         return jsonify({"error": "Empty filename"}), 400
 
-    if not allowed_file(file.filename):
+    if not allowed_file(filename):
         return jsonify({"error": "Invalid file type"}), 400
 
-    ext = file.filename.rsplit(".", 1)[1].lower()
+    ext = filename.rsplit(".", 1)[1].lower()
     unique_filename = f"{uuid.uuid4().hex}.{ext}"
 
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)

--- a/front/src/quiz/controller/question_controller.py
+++ b/front/src/quiz/controller/question_controller.py
@@ -1,7 +1,9 @@
 import json
+from typing import cast
 
 from flask import abort, jsonify, make_response, request
 from flask_login import current_user, login_required
+from miminet_model import User
 from quiz.facade.question_facade import create_question, delete_question
 from quiz.service.question_service import get_questions_by_section
 from quiz.util.encoder import UUIDEncoder
@@ -22,7 +24,7 @@ def get_questions_by_section_endpoint():
 @login_required
 def create_question_endpoint():
     section_id = request.args.get("id", None)
-    res = create_question(section_id, request.json, current_user)
+    res = create_question(section_id, request.json, cast(User, current_user))
     if res[1] == 404 and "message" in res[0]:
         msg = res[0]["message"]
         ret = {"message": f"{msg}"}
@@ -52,7 +54,7 @@ def create_question_endpoint():
 def delete_question_endpoint():
     question_id = request.args["id"]
 
-    res = delete_question(request.args["id"], current_user)
+    res = delete_question(request.args["id"], cast(User, current_user))
     if res == 404:
         ret = {"message": "Вопрос не существует", "id": question_id}
     elif res == 403:

--- a/front/src/quiz/controller/quiz_session_controller.py
+++ b/front/src/quiz/controller/quiz_session_controller.py
@@ -1,7 +1,9 @@
 import json
+from typing import cast
 
 from flask import abort, jsonify, make_response, render_template, request
 from flask_login import current_user, login_required
+from miminet_model import User
 from quiz.facade.quiz_session_facade import (
     finish_old_sessions,
     finish_session,
@@ -20,7 +22,9 @@ from quiz.service.session_question_service import (
 
 @login_required
 def answer_on_session_question_endpoint():
-    res = answer_on_session_question(request.args["id"], request.json, current_user)
+    res = answer_on_session_question(
+        request.args["id"], request.json, cast(User, current_user)
+    )
     if res[1] == 404 or res[1] == 403:
         abort(res[1])
     return make_response(json.dumps(res[0].to_dict(), default=str), res[1])
@@ -43,7 +47,7 @@ def get_session_question_json():
 def check_network_task_endpoint():
     session_question_id = request.args["id"]
     answer = request.json
-    user = current_user
+    user = cast(User, current_user)
 
     result, aux, status = handle_exam_answer(session_question_id, answer, user)
 
@@ -93,7 +97,7 @@ def get_question_by_session_question_id_endpoint():
 
 @login_required
 def start_session_endpoint():
-    res = start_session(request.args["section_id"], current_user)
+    res = start_session(request.args["section_id"], cast(User, current_user))
 
     if res[2] == 404:
         abort(res[2])
@@ -106,7 +110,7 @@ def start_session_endpoint():
 
 @login_required
 def finish_session_endpoint():
-    code = finish_session(request.args["id"], current_user)
+    code = finish_session(request.args["id"], cast(User, current_user))
 
     if code == 404 or code == 403:
         abort(code)
@@ -116,7 +120,7 @@ def finish_session_endpoint():
 
 @login_required
 def finish_old_session_endpoint():
-    code = finish_old_sessions(current_user)
+    code = finish_old_sessions(cast(User, current_user))
 
     if code == 404:
         abort(404)

--- a/front/src/quiz/controller/section_controller.py
+++ b/front/src/quiz/controller/section_controller.py
@@ -1,8 +1,10 @@
 import json
 from datetime import datetime
+from typing import cast
 
 from flask import abort, jsonify, make_response, render_template, request
 from flask_login import current_user, login_required
+from miminet_model import User
 from quiz.service.section_service import (
     create_section,
     delete_section,
@@ -18,7 +20,7 @@ from quiz.util.encoder import UUIDEncoder
 
 @login_required
 def create_section_endpoint():
-    user = current_user
+    user = cast(User, current_user)
     res = create_section(
         name=request.json["name"],
         description=request.json["description"],
@@ -61,7 +63,9 @@ def get_sections_by_test_endpoint():
 
 @login_required
 def get_deleted_sections_by_test_endpoint():
-    res = get_deleted_sections_by_test(request.args["test_id"], current_user)
+    res = get_deleted_sections_by_test(
+        request.args["test_id"], cast(User, current_user)
+    )
     if res[1] == 404 or res[1] == 403:
         abort(res[1])
     else:
@@ -73,7 +77,7 @@ def get_deleted_sections_by_test_endpoint():
 @login_required
 def delete_section_endpoint():
     section_id = request.args["id"]
-    deleted = delete_section(current_user, section_id)
+    deleted = delete_section(cast(User, current_user), section_id)
     if deleted == 404:
         ret = {"message": "Раздел не существует", "id": section_id}
     elif deleted == 403:
@@ -88,7 +92,7 @@ def delete_section_endpoint():
 def edit_section_endpoint():
     section_id = request.json["id"]
     edited = edit_section(
-        user=current_user,
+        user=cast(User, current_user),
         name=request.json["name"],
         section_id=section_id,
         description=request.json["description"],
@@ -109,7 +113,9 @@ def publish_or_unpublish_test_by_section_endpoint():
     is_to_publish = request.json["to_publish"]
     section_id = request.args["id"]
     published = publish_or_unpublish_test_by_section(
-        user=current_user, section_id=section_id, is_to_publish=is_to_publish
+        user=cast(User, current_user),
+        section_id=section_id,
+        is_to_publish=is_to_publish,
     )
     if published == 404:
         ret = {"message": "Тест по данной секции не существует", "id": section_id}

--- a/front/src/quiz/controller/test_controller.py
+++ b/front/src/quiz/controller/test_controller.py
@@ -1,7 +1,9 @@
 import json
+from typing import cast
 
 from flask import abort, jsonify, make_response, render_template, request
 from flask_login import current_user, login_required
+from miminet_model import User
 from quiz.service.test_service import (
     create_test,
     delete_test,
@@ -19,7 +21,7 @@ from quiz.util.encoder import UUIDEncoder
 
 @login_required
 def create_test_endpoint():
-    user = current_user
+    user = cast(User, current_user)
     res_id = create_test(
         name=request.json["name"],
         description=request.json["description"],
@@ -42,7 +44,7 @@ def get_test_endpoint():
 
 @login_required
 def get_tests_by_owner_endpoint():
-    user = current_user
+    user = cast(User, current_user)
     res = get_tests_by_owner(user)
 
     return make_response(
@@ -65,7 +67,7 @@ def get_retakeable_tests_endpoint():
 
 @login_required
 def get_deleted_tests_by_owner_endpoint():
-    user = current_user
+    user = cast(User, current_user)
     res = get_deleted_tests_by_owner(user)
 
     return make_response(
@@ -76,7 +78,7 @@ def get_deleted_tests_by_owner_endpoint():
 @login_required
 def delete_test_endpoint():
     test_id = request.args["id"]
-    deleted = delete_test(current_user, test_id)
+    deleted = delete_test(cast(User, current_user), test_id)
     if deleted == 404:
         ret = {"message": "Тест не существует", "id": test_id}
     elif deleted == 403:
@@ -93,7 +95,7 @@ def delete_test_endpoint():
 def edit_test_endpoint():
     test_id = request.json["id"]
     edited = edit_test(
-        user=current_user,
+        user=cast(User, current_user),
         name=request.json["name"],
         test_id=test_id,
         description=request.json["description"],
@@ -123,7 +125,7 @@ def publish_or_unpublish_test_endpoint():
     is_to_publish = request.json["to_publish"]
     test_id = request.args["id"]
     published = publish_or_unpublish_test(
-        user=current_user, test_id=test_id, is_to_publish=is_to_publish
+        user=cast(User, current_user), test_id=test_id, is_to_publish=is_to_publish
     )
     if published == 404:
         ret = {"message": "Тест не существует", "id": test_id}

--- a/front/src/quiz/facade/question_facade.py
+++ b/front/src/quiz/facade/question_facade.py
@@ -18,7 +18,7 @@ from quiz.facade.json_schema_validation import validate_requirements
 UPLOAD_FOLDER = "/app/static/quiz_images"
 
 
-def create_single_question(section_id: str, question_dict, user: User):
+def create_single_question(section_id: str | None, question_dict, user: User):
     if "requirements" in question_dict:
         validation_result = validate_requirements(question_dict["requirements"])
         if validation_result is not True:
@@ -162,7 +162,7 @@ def create_single_question(section_id: str, question_dict, user: User):
     return question.id, 201
 
 
-def create_question(section_id: str, question_data, user: User):
+def create_question(section_id: str | None, question_data, user: User):
     """
     Если question_data – список, то обрабатывает все объекты.
     Если одиночный объект – обрабатывает его.

--- a/front/src/quiz/service/session_question_service.py
+++ b/front/src/quiz/service/session_question_service.py
@@ -66,7 +66,7 @@ def get_question_by_session_question_id(session_question_id: str):
     )
 
 
-def get_session_question_data(session_question_id: str):
+def get_session_question_data(session_question_id: str | None):
     if not session_question_id:
         return None, 400
 

--- a/front/src/quiz/util/dto.py
+++ b/front/src/quiz/util/dto.py
@@ -31,7 +31,7 @@ def calculate_question_count(section: Section) -> int:
             return sum(meta_data.values())
         except json.JSONDecodeError:
             return 0
-    return len(section.questions)
+    return len(cast(Any, section.questions))
 
 
 MOSCOW_TZ = ZoneInfo("Europe/Moscow")

--- a/front/src/quiz/util/encoder.py
+++ b/front/src/quiz/util/encoder.py
@@ -3,8 +3,8 @@ from uuid import UUID
 
 
 class UUIDEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, UUID):
-            return obj.hex
+    def default(self, o):
+        if isinstance(o, UUID):
+            return o.hex
 
-        return json.JSONEncoder.default(self, obj)
+        return json.JSONEncoder.default(self, o)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,12 @@ include = ["**"]
 
 [tool.ty.overrides.analysis]
 allowed-unresolved-imports = ["**"]
+
+# Staging: ty checks untyped bodies (mypy skipped them), so front/tests carries
+# ~133 diagnostics today. mypy never meaningfully checked these files (untyped
+# defs) — this is not a coverage regression. Re-enable once src is clean.
+[[tool.ty.overrides]]
+include = ["front/tests"]
+
+[tool.ty.overrides.rules]
+all = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,14 @@ include = ["front/tests"]
 
 [tool.ty.overrides.rules]
 all = "ignore"
+
+# flask_sqlalchemy's db.Model is built through a dynamic metaclass that ty
+# cannot resolve to a concrete base — every declarative model class inheriting
+# db.Model trips `unsupported-base` (mypy-era `# type: ignore[name-defined]`
+# comments mark the same known limitation). Scoped to the two model-definition
+# files; unsupported-base stays enabled everywhere else.
+[[tool.ty.overrides]]
+include = ["front/src/miminet_model.py", "front/src/quiz/entity/entity.py"]
+
+[tool.ty.overrides.rules]
+unsupported-base = "ignore"


### PR DESCRIPTION
## What & why

`mypy --ignore-missing-imports back|front` reported 0 errors only because mypy
skips untyped function bodies — the gate was vacuous over a ~24%-annotated
codebase. This PR swaps the linter's type gate to **ty** (astral, already a dev
dep), which checks untyped bodies unconditionally, and makes `back` + `front`
src trees pass under it.

## Commits

1. **`ci(lint): gate with ty instead of mypy`** — linter.yml mypy step → `ty check`;
   `[tool.ty]` staging override keeps `front/tests` out of the gate for now
   (mypy never meaningfully checked them either; untyped defs) — a separate later
   phase re-enables them. Tooling only.
2. **`fix(back): ...`** + **`fix(front): ...`** — the type-fix sweep, isolated from
   the tooling commit in history.

## Latent bugs found by ty (the value)

- `back/bench/bench.py`: referenced `psutil.ProcessLookupError`, which does not
  exist — evaluating that except-tuple raised `AttributeError` whenever a process
  vanished mid-iteration (psutil ships `py.typed`, so mypy's ignore-missing didn't
  hide this; ty resolved it).
- `front/src/miminet_network.py::get_emulation_queue_size`: absent `time-filter`
  → `request.args.get(...) is None` → `None.replace`/`fromisoformat` → 500.
  Now returns the documented 400.
- `front/src/quiz/controller/image_controller.py::upload_image_endpoint`:
  `file.filename` can be `None`; the empty-string check didn't cover it, so
  `allowed_file(None)` crashed. Guarded with `if not filename`.
- `front/src/quiz/controller/image_controller.py` + others: cross-method
  Optional-state derefs guarded with invariant asserts.
- `front/src/quiz/controller/question_controller.py`-adjacent facade params
  widened to `str | None` where the code genuinely accepts absent ids.

## Notes for reviewers

- `front/src/miminet_admin.py` date column formatter gained the missing `name`
  param (flask-admin calls `(view, value, name)`); 2-arg was only tolerated by
  backwards-compat.
- `db.Model` `unsupported-base` warnings (dynamic flask_sqlalchemy metaclass) are
  silenced via a scoped `[tool.ty]` override for the two model-definition files —
  not blanket.
- Several boundaries use `cast(Any, ...)` for unannotated `db.relationship`
  attrs in `selectinload` — matches the pre-existing `test_service.py` convention.