### PR TITLE
test(ty): re-enable type gate on front/tests (fix 133 diagnostics)

### DIFF
--- a/front/tests/conftest.py
+++ b/front/tests/conftest.py
@@ -15,6 +15,7 @@ from selenium.common.exceptions import (
 )
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.remote.command import Command
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
@@ -288,7 +289,10 @@ class MiminetTester(WebDriver):
         Returns:
             list: list with the filtered log entries.
         """
-        logs = self.get_log("browser")
+        # Remote WebDriver has no `get_log` in Selenium 4 (it lives only on
+        # ChromiumDriver); the grid session is a chromedriver underneath, so run
+        # the same GET_LOG command ChromiumDriver.get_log would run.
+        logs = self.execute(Command.GET_LOG, {"type": "browser"})["value"]
         return list(filter(logs_filter, logs)) if logs_filter else list(logs)
 
     def get_console_messages(self):

--- a/front/tests/utils/locators.py
+++ b/front/tests/utils/locators.py
@@ -2,25 +2,65 @@ from typing import Optional
 
 
 class Locator:
-    """Holds different types of locators for UI elements."""
+    """Holds different types of locators for UI elements.
 
-    def __init__(self, selector=None, xpath=None, text=None, **kwargs):
-        self.xpath = xpath
-        self.selector = selector
-        self.text = text
+    A locator is built with the strategy it needs (CSS ``selector``,
+    ``xpath``, and/or ``text``). Each accessor is a typed property that
+    asserts the strategy was provided at construction, so a read that
+    requests a strategy the locator does not carry fails loudly instead of
+    flowing ``None`` into a Selenium call.
+    """
+
+    def __init__(
+        self,
+        selector: Optional[str] = None,
+        xpath: Optional[str] = None,
+        text: Optional[str] = None,
+        **kwargs,
+    ):
+        self._selector = selector
+        self._xpath = xpath
+        self._text = text
 
         for key, value in kwargs.items():
             setattr(self, key, value)
+
+    @property
+    def selector(self) -> str:
+        assert self._selector is not None, "Locator was not built with a selector"
+        return self._selector
+
+    @property
+    def xpath(self) -> str:
+        assert self._xpath is not None, "Locator was not built with an xpath"
+        return self._xpath
+
+    @property
+    def text(self) -> str:
+        assert self._text is not None, "Locator was not built with text"
+        return self._text
 
 
 class DeviceLocator(Locator):
     """Holds different types of locators for network devices."""
 
     def __init__(
-        self, selector=None, xpath=None, text=None, device_class=None, **kwargs
+        self,
+        selector: Optional[str] = None,
+        xpath: Optional[str] = None,
+        text: Optional[str] = None,
+        device_class: Optional[str] = None,
+        **kwargs,
     ):
         super().__init__(selector=selector, xpath=xpath, text=text, **kwargs)
-        self.device_class = device_class
+        self._device_class = device_class
+
+    @property
+    def device_class(self) -> str:
+        assert self._device_class is not None, (
+            "DeviceLocator was not built with a device_class"
+        )
+        return self._device_class
 
 
 class Location:

--- a/front/tests/utils/networks.py
+++ b/front/tests/utils/networks.py
@@ -12,11 +12,26 @@ from utils.locators import Location
 class NodeType:
     """Node types for testing purposes."""
 
-    Host = (By.CSS_SELECTOR, Location.Network.DevicePanel.HOST.selector)
-    Switch = (By.CSS_SELECTOR, Location.Network.DevicePanel.SWITCH.selector)
-    Router = (By.CSS_SELECTOR, Location.Network.DevicePanel.ROUTER.selector)
-    Hub = (By.CSS_SELECTOR, Location.Network.DevicePanel.HUB.selector)
-    Server = (By.CSS_SELECTOR, Location.Network.DevicePanel.SERVER.selector)
+    Host: Tuple[str, str] = (
+        By.CSS_SELECTOR,
+        Location.Network.DevicePanel.HOST.selector,
+    )
+    Switch: Tuple[str, str] = (
+        By.CSS_SELECTOR,
+        Location.Network.DevicePanel.SWITCH.selector,
+    )
+    Router: Tuple[str, str] = (
+        By.CSS_SELECTOR,
+        Location.Network.DevicePanel.ROUTER.selector,
+    )
+    Hub: Tuple[str, str] = (
+        By.CSS_SELECTOR,
+        Location.Network.DevicePanel.HUB.selector,
+    )
+    Server: Tuple[str, str] = (
+        By.CSS_SELECTOR,
+        Location.Network.DevicePanel.SERVER.selector,
+    )
 
 
 class MiminetTestNetwork:
@@ -263,8 +278,10 @@ class NodeConfig:
     @property
     def name(self):
         """Current name of the network device displayed in the configuration."""
+        name_field = self.__config_locator.NAME_FIELD
+        assert name_field is not None
         name = self.__selenium.find_element(
-            By.CSS_SELECTOR, self.__config_locator.NAME_FIELD.selector
+            By.CSS_SELECTOR, name_field.selector
         ).get_attribute("value")
 
         return name
@@ -272,8 +289,10 @@ class NodeConfig:
     @property
     def default_gw(self):
         """Current default gateway of the network device displayed in the configuration."""
+        gw_field = self.__config_locator.DEFAULT_GATEWAY_FIELD
+        assert gw_field is not None
         gw = self.__selenium.find_element(
-            By.CSS_SELECTOR, self.__config_locator.DEFAULT_GATEWAY_FIELD.selector
+            By.CSS_SELECTOR, gw_field.selector
         ).get_attribute("value")
 
         return gw
@@ -507,14 +526,14 @@ class NodeConfig:
         """Submit configuration."""
         self.__check_config_open()
 
-        self.__selenium.wait_and_click(
-            By.CSS_SELECTOR, self.__config_locator.SUBMIT_BUTTON.selector
-        )
+        submit_button = self.__config_locator.SUBMIT_BUTTON
+        assert submit_button is not None
+        self.__selenium.wait_and_click(By.CSS_SELECTOR, submit_button.selector)
 
         self.__selenium.wait_until_text(
             By.CSS_SELECTOR,
-            self.__config_locator.SUBMIT_BUTTON.selector,
-            self.__config_locator.SUBMIT_BUTTON.text,
+            submit_button.selector,
+            submit_button.text,
             timeout=20,
         )
 
@@ -525,9 +544,9 @@ class NodeConfig:
             or self.__config_locator == Location.Network.ConfigPanel.Server
             or self.__config_locator == Location.Network.ConfigPanel.Switch
         ):
-            self.__selenium.select_by_value(
-                by, self.__config_locator.JOB_SELECT.selector, str(job_id)
-            )
+            job_select = self.__config_locator.JOB_SELECT
+            assert job_select is not None
+            self.__selenium.select_by_value(by, job_select.selector, str(job_id))
         else:
             raise ValueError(
                 f"Can't add job. Node with type {self.__config_locator} can't use jobs"
@@ -571,10 +590,10 @@ class NodeConfig:
 
     def __check_config_open(self):
         """Check that the config is open and handle any errors."""
+        main_form = self.__config_locator.MAIN_FORM
+        assert main_form is not None
         try:
-            self.__selenium.find_element(
-                By.CSS_SELECTOR, self.__config_locator.MAIN_FORM.selector
-            )
+            self.__selenium.find_element(By.CSS_SELECTOR, main_form.selector)
         except NoSuchElementException:
             raise Exception("Config panel isn't open during some operation.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,6 @@ include = ["**"]
 [tool.ty.overrides.analysis]
 allowed-unresolved-imports = ["**"]
 
-# Staging: ty checks untyped bodies (mypy skipped them), so front/tests carries
-# ~133 diagnostics today. mypy never meaningfully checked these files (untyped
-# defs) — this is not a coverage regression. Re-enable once src is clean.
-[[tool.ty.overrides]]
-include = ["front/tests"]
-
-[tool.ty.overrides.rules]
-all = "ignore"
-
 # flask_sqlalchemy's db.Model is built through a dynamic metaclass that ty
 # cannot resolve to a concrete base — every declarative model class inheriting
 # db.Model trips `unsupported-base` (mypy-era `# type: ignore[name-defined]`


### PR DESCRIPTION
## What
Removes the `front/tests` staging override from `[tool.ty]` in the root
`pyproject.toml`, so the Linter ty gate (`ty check front`) now covers the
Selenium e2e layer too. ~133 diagnostics were staged out when the ty gate
was adopted in #485; mypy never meaningfully checked those files (untyped
defs), so this is not a coverage regression — it completes the gate.

## How (fix at the DSL root, tests untouched)
Root cause of the bulk of the diagnostics was the test DSL, not the 25
test files:
- `front/tests/utils/locators.py` — `Locator`/`DeviceLocator` stored
  untyped, None-defaulted `selector`/`xpath`/`text`/`device_class` fields,
  so every class-constant `Location.*.selector` read typed as
  `Unknown | None` and leaked into every helper call. Fields are now typed
  read-only properties that assert the strategy was provided at
  construction (a mismatched read fails loudly instead of flowing `None`
  into Selenium). Audited: all 76 distinct `Location.*` read sites in the
  suite resolve against locators built with the field they read.
- `front/tests/utils/networks.py` — `NodeType` members annotated
  `tuple[str, str]` (collapses ~79 `add_node` call-site diagnostics at the
  source); `NodeConfig` reads of `CommonDevice`'s `Optional[Locator]` base
  fields narrowed with asserts mirroring the pre-existing
  `assert ... MAIN_FORM` pattern.
- `front/tests/conftest.py` — **latent bug ty found**: `get_logs()` called
  `self.get_log("browser")`, which does not exist on remote `WebDriver` in
  Selenium 4 (only `ChromiumDriver` has it) — the dead path would have
  raised `AttributeError` if invoked. Now runs the same `GET_LOG` wire
  command `ChromiumDriver.get_log` uses, so a grid session returns logs.

## Verification
- `ty check front` and `ty check back`: 0 errors on the final tree.
- `ruff check` + `ruff format --check` clean.
- All 25 `front/tests/test_*.py` modules import cleanly.
- The front/src `unsupported-base` scoped ignores are unchanged.

## Review asks
1. Locator property asserts: reachable-path behavior unchanged? Any read
   site I missed where a locator legitimately lacks the field being read?
2. `get_logs()` GET_LOG rewording: is the wire command equivalent to the
   old intent (grid chrome session)?
3. `NodeConfig` assert-narrowing: can any reachable path hit the new
   asserts (i.e. a config class without the field being read)?