### PR TITLE
feat(front): honor SQLALCHEMY_DATABASE_URI env override

### DIFF
--- a/front/src/app.py
+++ b/front/src/app.py
@@ -235,7 +235,12 @@ def get_database_uri(mode):
         raise ValueError(f"Unknown MODE: {mode}. Expected 'dev' or 'prod'")
 
 
-app.config["SQLALCHEMY_DATABASE_URI"] = get_database_uri(MODE)
+# Explicit SQLALCHEMY_DATABASE_URI overrides MODE-based selection (used by
+# tests and ephemeral local runs to point at a throwaway DB without changing
+# MODE or touching real credentials).
+app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("SQLALCHEMY_DATABASE_URI") or (
+    get_database_uri(MODE)
+)
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = True
 app.config["SECRET_KEY"] = SECRET_KEY
 app.config["SESSION_COOKIE_NAME"] = "mimi_session"

--- a/front/src/miminet_model.py
+++ b/front/src/miminet_model.py
@@ -200,8 +200,20 @@ def init_db(app):
         else:
             raise ValueError(f"Unknown MODE: {mode}")
 
-        # Проверить/создать БД для обоих режимов
-        if postgres_host and postgres_user and postgres_password and postgres_db:
+        # Проверить/создать БД для обоих режимов. Provisioning is only
+        # meaningful for the MODE-derived target: an explicit
+        # SQLALCHEMY_DATABASE_URI override (same truth test as app.py) means
+        # the caller owns the database (create a throwaway postgres beforehand;
+        # sqlite is auto-created by the engine), so never probe or auto-create
+        # the real dev/prod database from the mode env vars.
+        uri_override = os.getenv("SQLALCHEMY_DATABASE_URI")
+        if (
+            not uri_override
+            and postgres_host
+            and postgres_user
+            and postgres_password
+            and postgres_db
+        ):
             ensure_db_exists(
                 postgres_host,
                 postgres_user,


### PR DESCRIPTION
App-construction seam per architecture review (Batch 12 MUST-FIX #1).

- Lazy `SQLALCHEMY_DATABASE_URI` env override around `get_database_uri(MODE)`.
- Default MODE-based behavior unchanged; prod-without-creds still raises unless overridden.
- Enables tests / ephemeral local runs to use a throwaway DB without touching real credentials.

Local gates: ty check + ruff check + ruff format green.