### PR TITLE
build(back): bump ipmininet fork to v1.3.0

### DIFF
--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "marshmallow-dataclass==8.7.1",
     "psutil==7.2.2",
     "netaddr==1.3.0",
-    "ipmininet @ git+https://github.com/mimi-net/ipmininet.git@v1.2.7",
+    "ipmininet @ git+https://github.com/mimi-net/ipmininet.git@v1.3.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -790,8 +790,8 @@ wheels = [
 
 [[package]]
 name = "ipmininet"
-version = "1.2.7"
-source = { git = "https://github.com/mimi-net/ipmininet.git?rev=v1.2.7#058d4ea7c31d4959156bc1993cda535c394a3b70" }
+version = "1.3.0"
+source = { git = "https://github.com/mimi-net/ipmininet.git?rev=v1.3.0#d3ce325808a32b5f8b2d6757a454cdb461637788" }
 dependencies = [
     { name = "mako" },
     { name = "mininet" },
@@ -1199,7 +1199,7 @@ dev = [
 requires-dist = [
     { name = "celery", specifier = "==5.6.3" },
     { name = "dpkt", specifier = "==1.9.8" },
-    { name = "ipmininet", git = "https://github.com/mimi-net/ipmininet.git?rev=v1.2.7" },
+    { name = "ipmininet", git = "https://github.com/mimi-net/ipmininet.git?rev=v1.3.0" },
     { name = "marshmallow-dataclass", specifier = "==8.7.1" },
     { name = "netaddr", specifier = "==1.3.0" },
     { name = "psutil", specifier = "==7.2.2" },


### PR DESCRIPTION
DT-ipmininet-1.3.0 gate passed: pin v1.2.7 -> v1.3.0, uv.lock updated (only ipmininet rev changed), **full rootless back suite green: 139 passed**.

miminet uses ipmininet as kernel-level L3 + captures only (no FRR daemon ever registered), so the v1.3.0 FRR 10.7.1/mgmtd + ExaBGP + OpenR changes are irrelevant. Valuation: docs/experiments/ipmininet-1.3.0-upgrade/00-valuation.md.