### PR TITLE
feat(front): accept bearer JWT via Authorization header

### DIFF
--- a/front/src/app.py
+++ b/front/src/app.py
@@ -128,7 +128,7 @@ MODE = os.getenv("MODE", "dev")
 
 app.config.update(
     JWT_SECRET_KEY=os.environ.get("JWT_SECRET_KEY", "secret-key"),
-    JWT_TOKEN_LOCATION=["cookies"],
+    JWT_TOKEN_LOCATION=["cookies", "headers"],
     JWT_COOKIE_DOMAIN=f".{BASE_DOMAIN}" if BASE_DOMAIN else None,
     JWT_COOKIE_SECURE=False if MODE == "dev" else True,
     JWT_COOKIE_CSRF_PROTECT=False if MODE == "dev" else True,


### PR DESCRIPTION
Additive auth/contract step gated by experiment D1 (docs/experiments/d1-prod-csrf/00-verdict.md).

D1 proved: under MODE=prod, cookie-JWT POSTs fail without X-CSRF-TOKEN (no browser JS sends it); the live stack only works because its .env sets MODE=dev. The safe additive fix for a future non-browser client is bearer transport — header-located JWTs are CSRF-exempt by design.

Change: JWT_TOKEN_LOCATION ["cookies"] -> ["cookies", "headers"]. Browser cookie flow unchanged (cookies first); CORS already allows Authorization.

Gates: ty + ruff check + ruff format green; auth_tests 30 passed (tg_test error is missing BOT_TOKEN secret, env-only, CI injects it).