### PR TITLE
ci(front): browser-free coverage job with baseline gate

### DIFF
--- a/.github/workflows/front_coverage.yml
+++ b/.github/workflows/front_coverage.yml
@@ -1,0 +1,61 @@
+name: Front browser-free coverage
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install dependencies
+        run: |
+          uv sync --frozen
+
+      - name: Run browser-free unit tests under coverage
+        run: |
+          source .venv/bin/activate
+          cd front/tests
+          # Explicit list of browser-free test files (no selenium grid / no
+          # live compose needed). If a future file is added here it must be
+          # added to the list explicitly — `find` is deliberately NOT used so
+          # the browser-free set never silently changes shape.
+          files=(
+            test_get_logs.py
+            test_config_db.py
+            test_quiz_progress.py
+            test_ai_generate.py
+          )
+          [ "${#files[@]}" -gt 0 ] || { echo "ERROR: empty browser-free file list" >&2; exit 1; }
+          printf 'Browser-free files: %s\n' "${files[@]}"
+          # Raw coverage CLI (not pytest-cov), matching the back_test.yml
+          # pattern. --source=../src maps to front/src; --data-file is cwd-
+          # relative (front/tests).
+          python -m coverage run --branch --source=../src \
+            --data-file=".coverage.browserfree" -m pytest -vv -s \
+            -o log_file=/dev/null -o log_cli=true "${files[@]}"
+          # Gate at the measured whole-suite baseline (22.65% statements on
+          # upstream/main from the 4 browser-free files, measured 2026-09-06)
+          # rounded down to 21% — a browser-free regression now fails the PR.
+          python -m coverage report --fail-under=21
+          python -m coverage json -o coverage.json
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: front-browserfree-coverage-report
+          path: front/tests/coverage.json
+          include-hidden-files: true
+          if-no-files-found: ignore

--- a/.github/workflows/front_coverage.yml
+++ b/.github/workflows/front_coverage.yml
@@ -45,11 +45,15 @@ jobs:
           python -m coverage run --branch --source=../src \
             --data-file=".coverage.browserfree" -m pytest -vv -s \
             -o log_file=/dev/null -o log_cli=true "${files[@]}"
-          # Gate at the measured whole-suite baseline (22.65% statements on
-          # upstream/main from the 4 browser-free files, measured 2026-09-06)
-          # rounded down to 21% — a browser-free regression now fails the PR.
-          python -m coverage report --fail-under=21
-          python -m coverage json -o coverage.json
+          # Gate at the measured whole-suite baseline (22.65% blended
+          # stmts+branches on upstream/main from the 4 browser-free files,
+          # measured 2026-09-06) rounded down to 21% — a browser-free
+          # regression now fails the PR. report/json read the run's data file
+          # explicitly (no reliance on coverage's implicit auto-combine).
+          python -m coverage report --fail-under=21 \
+            --data-file=".coverage.browserfree"
+          python -m coverage json -o coverage.json \
+            --data-file=".coverage.browserfree"
 
       - name: Upload coverage report
         if: always()

--- a/front/pyproject.toml
+++ b/front/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest-mock==3.15.1",
     "pytest-timeout==2.4.0",
     "selenium",
+    "coverage>=7.16.0",
     "isort",
     "mypy",
     "types-requests",

--- a/uv.lock
+++ b/uv.lock
@@ -1253,6 +1253,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1295,6 +1296,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage", specifier = ">=7.16.0" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest", specifier = "==9.0.3" },


### PR DESCRIPTION
Fixes the front coverage infra gap (architecture review lens-C F3). Mirrors back_test.yml patterns.

- coverage >=7.16.0 added to the front dev group (uv.lock only; wheel already resolved for back).
- New non-matrix, non-compose, no-grid job running the 4 browser-free test files (test_get_logs, test_config_db, test_quiz_progress, test_ai_generate) under raw coverage CLI over front/src.
- Gate fail-under=21 (measured whole-suite baseline 22.65% on 2026-09-06, rounded down); a browser-free regression now fails the PR.
- Explicit browser-free file list as an array with empty-slice guard; coverage.json artifact with include-hidden-files: true.

Local replica of the exact job sequence: 23 passed, FAIL-UNDER-GATE-OK.